### PR TITLE
GROUNDWORK-491-build-fix:  complete the changes for "go test"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,4 +49,4 @@ jansson-2.12/*
 *.tar.gz
 
 # Build directory
-BUILD
+build

--- a/Makefile
+++ b/Makefile
@@ -46,11 +46,11 @@ endif
 
 # The current definition here is a placeholder for whatever we actually
 # want to use according to some sort of project-standard file tree.
-BUILD_TARGET_DIRECTORY = BUILD
+BUILD_TARGET_DIRECTORY = build
 
 CONVERT_GO_TO_C_BUILD_OBJECTS = \
-	gotocjson/convert_go_to_c.c	\
-	gotocjson/convert_go_to_c.h
+	gotocjson/_c_code/convert_go_to_c.c	\
+	gotocjson/_c_code/convert_go_to_c.h
 
 MILLISECONDS_BUILD_OBJECTS = \
 	${BUILD_TARGET_DIRECTORY}/milliseconds.c	\
@@ -122,13 +122,13 @@ ${TRANSIT_BUILD_OBJECTS}	: gotocjson/gotocjson transit/transit.go | ${BUILD_TARG
 	gotocjson/gotocjson -o ${BUILD_TARGET_DIRECTORY} transit/transit.go
 
 ${BUILD_TARGET_DIRECTORY}/convert_go_to_c.o	: ${CONVERT_GO_TO_C_BUILD_OBJECTS} | ${BUILD_TARGET_DIRECTORY}
-	${CC} -c gotocjson/convert_go_to_c.c -o $@ -Igotocjson -I${JANSSON_INCLUDE_DIRECTORY}
+	${CC} -c gotocjson/_c_code/convert_go_to_c.c -o $@ -I${JANSSON_INCLUDE_DIRECTORY}
 
 ${BUILD_TARGET_DIRECTORY}/milliseconds.o	: ${MILLISECONDS_BUILD_OBJECTS}
-	${CC} -c ${BUILD_TARGET_DIRECTORY}/milliseconds.c -o $@ -Igotocjson -I${JANSSON_INCLUDE_DIRECTORY}
+	${CC} -c ${BUILD_TARGET_DIRECTORY}/milliseconds.c -o $@ -Igotocjson/_c_code -I${JANSSON_INCLUDE_DIRECTORY}
 
 ${BUILD_TARGET_DIRECTORY}/transit.o	: ${TRANSIT_BUILD_OBJECTS}
-	${CC} -c ${BUILD_TARGET_DIRECTORY}/transit.c -o $@ -Igotocjson -I${JANSSON_INCLUDE_DIRECTORY}
+	${CC} -c ${BUILD_TARGET_DIRECTORY}/transit.c -o $@ -Igotocjson/_c_code -I${JANSSON_INCLUDE_DIRECTORY}
 
 ${LIBTRANSITJSON_LIBRARY}	: ${LIBTRANSITJSON_OBJECTS} ${JANSSON_LIBRARY}
 	${LINK.c} -shared -o $@ -fPIC ${LIBTRANSITJSON_OBJECTS} ${JANSSON_LINK_FLAGS}

--- a/gotocjson/Makefile
+++ b/gotocjson/Makefile
@@ -49,7 +49,7 @@ endif
 
 # The current definition here is a placeholder for whatever we actually
 # want to use according to some sort of project-standard file tree.
-BUILD_TARGET_DIRECTORY = BUILD
+BUILD_TARGET_DIRECTORY = build
 
 # We currently specify "-g" to assist in debugging and possibly also in memory-leak detection.
 CFLAGS = -std=c11 -g


### PR DESCRIPTION
Previous changes to support "go test" were slightly incomplete,
and broke the build because some code had been relocated and
a few references to that code had not been likewise updated.

Also change the "BUILD" directory to the "build" directory, to
reflect what will probably be our convention going forward.