### PR TITLE
GROUNDWORK-681-libtransit-build:  conversion-tool and build changes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -59,12 +59,12 @@ CONVERT_GO_TO_C_BUILD_OBJECTS = \
 	gotocjson/_c_code/convert_go_to_c.h
 
 CONFIG_BUILD_OBJECTS = \
-	${BUILD_TARGET_DIRECTORY}/config.c	\
-	${BUILD_TARGET_DIRECTORY}/config.h
+	${BUILD_TARGET_DIRECTORY}/setup.c	\
+	${BUILD_TARGET_DIRECTORY}/setup.h
 
 MILLISECONDS_BUILD_OBJECTS = \
-	${BUILD_TARGET_DIRECTORY}/milliseconds.c	\
-	${BUILD_TARGET_DIRECTORY}/milliseconds.h
+	${BUILD_TARGET_DIRECTORY}/subseconds.c	\
+	${BUILD_TARGET_DIRECTORY}/subseconds.h
 
 TRANSIT_BUILD_OBJECTS =	\
 	${BUILD_TARGET_DIRECTORY}/transit.c		\
@@ -72,8 +72,8 @@ TRANSIT_BUILD_OBJECTS =	\
 
 LIBTRANSITJSON_OBJECTS = \
 	${BUILD_TARGET_DIRECTORY}/convert_go_to_c.o	\
-	${BUILD_TARGET_DIRECTORY}/config.o		\
-	${BUILD_TARGET_DIRECTORY}/milliseconds.o	\
+	${BUILD_TARGET_DIRECTORY}/setup.o		\
+	${BUILD_TARGET_DIRECTORY}/subseconds.o	\
 	${BUILD_TARGET_DIRECTORY}/transit.o
 
 LIBTRANSIT_DIRECTORY = libtransit
@@ -89,8 +89,8 @@ LIBTRANSITJSON_LIBRARY = ${BUILD_TARGET_DIRECTORY}/libtransitjson.so
 BUILD_HEADER_FILES = \
 	${LIBTRANSIT_HEADER}				\
 	gotocjson/_c_code/convert_go_to_c.h		\
-	${BUILD_TARGET_DIRECTORY}/config.h		\
-	${BUILD_TARGET_DIRECTORY}/milliseconds.h	\
+	${BUILD_TARGET_DIRECTORY}/setup.h		\
+	${BUILD_TARGET_DIRECTORY}/subseconds.h	\
 	${BUILD_TARGET_DIRECTORY}/transit.h
 
 BUILD_DYNAMIC_LIBRARIES = \
@@ -173,11 +173,11 @@ ${INSTALL_BASE_DIRECTORY}/lib	:
 gotocjson/gotocjson	: gotocjson/gotocjson.go
 	cd gotocjson; make gotocjson
 
-${CONFIG_BUILD_OBJECTS}	: gotocjson/gotocjson config/config.go | ${BUILD_TARGET_DIRECTORY}
-	gotocjson/gotocjson -o ${BUILD_TARGET_DIRECTORY} config/config.go
+${CONFIG_BUILD_OBJECTS}	: gotocjson/gotocjson setup/config.go | ${BUILD_TARGET_DIRECTORY}
+	gotocjson/gotocjson -o ${BUILD_TARGET_DIRECTORY} setup/config.go
 
-${MILLISECONDS_BUILD_OBJECTS}	: gotocjson/gotocjson milliseconds/milliseconds.go | ${BUILD_TARGET_DIRECTORY}
-	gotocjson/gotocjson -o ${BUILD_TARGET_DIRECTORY} milliseconds/milliseconds.go
+${MILLISECONDS_BUILD_OBJECTS}	: gotocjson/gotocjson subseconds/milliseconds.go | ${BUILD_TARGET_DIRECTORY}
+	gotocjson/gotocjson -o ${BUILD_TARGET_DIRECTORY} subseconds/milliseconds.go
 
 ${TRANSIT_BUILD_OBJECTS}	: gotocjson/gotocjson transit/transit.go | ${BUILD_TARGET_DIRECTORY}
 	gotocjson/gotocjson -o ${BUILD_TARGET_DIRECTORY} transit/transit.go
@@ -185,11 +185,11 @@ ${TRANSIT_BUILD_OBJECTS}	: gotocjson/gotocjson transit/transit.go | ${BUILD_TARG
 ${BUILD_TARGET_DIRECTORY}/convert_go_to_c.o	: ${CONVERT_GO_TO_C_BUILD_OBJECTS} | ${BUILD_TARGET_DIRECTORY}
 	${CC} -c gotocjson/_c_code/convert_go_to_c.c -o $@ -I${JANSSON_INCLUDE_DIRECTORY}
 
-${BUILD_TARGET_DIRECTORY}/config.o	: ${CONFIG_BUILD_OBJECTS}
-	${CC} -c ${BUILD_TARGET_DIRECTORY}/config.c -o $@ -Igotocjson/_c_code -I${JANSSON_INCLUDE_DIRECTORY}
+${BUILD_TARGET_DIRECTORY}/setup.o	: ${CONFIG_BUILD_OBJECTS}
+	${CC} -c ${BUILD_TARGET_DIRECTORY}/setup.c -o $@ -Igotocjson/_c_code -I${JANSSON_INCLUDE_DIRECTORY}
 
-${BUILD_TARGET_DIRECTORY}/milliseconds.o	: ${MILLISECONDS_BUILD_OBJECTS}
-	${CC} -c ${BUILD_TARGET_DIRECTORY}/milliseconds.c -o $@ -Igotocjson/_c_code -I${JANSSON_INCLUDE_DIRECTORY}
+${BUILD_TARGET_DIRECTORY}/subseconds.o	: ${MILLISECONDS_BUILD_OBJECTS}
+	${CC} -c ${BUILD_TARGET_DIRECTORY}/subseconds.c -o $@ -Igotocjson/_c_code -I${JANSSON_INCLUDE_DIRECTORY}
 
 ${BUILD_TARGET_DIRECTORY}/transit.o	: ${TRANSIT_BUILD_OBJECTS}
 	${CC} -c ${BUILD_TARGET_DIRECTORY}/transit.c -o $@ -Igotocjson/_c_code -I${JANSSON_INCLUDE_DIRECTORY}

--- a/libtransit/Makefile
+++ b/libtransit/Makefile
@@ -1,6 +1,6 @@
 # Makefile for libtransit/ files
 
-libtransit.h libtransit.so	: libtransit.go ../config/config.go ../transit/*.go ../services/*.go ../log/*.go
+libtransit.h libtransit.so	: libtransit.go ../setup/config.go ../subseconds/milliseconds.go ../transit/*.go ../services/*.go ../log/*.go
 	    # go tool cgo [cgo options] [-- compiler options] libtransit.go
 	    # export GOPATH=${HOME}; go build -buildmode=c-shared -o libtransit.so libtransit.go
 	    go build -buildmode=c-shared -o libtransit.so libtransit.go


### PR DESCRIPTION
These changes are simply to support recent modifications elsewhere in TNG,
with some changes to source-file locations and generated-source-file names,
and one new feature (structure name aliasing used in one place) that needs
to be supported by the gotocjson conversion tool.