### PR TITLE
GROUNDWORK-787-make-empty-list:  generate allocation routines for lists

### DIFF
--- a/gotocjson/gotocjson.go
+++ b/gotocjson/gotocjson.go
@@ -1672,8 +1672,8 @@ func print_type_declarations(
 					fmt.Fprintf(header_file, "} %s;\n", list_type)
 					fmt.Fprintf(header_file, "\n")
 					fmt.Fprintf(header_file, "extern bool is_%[1]s_ptr_zero_value(const %[1]s *%[1]s_ptr);\n", list_type)
-					fmt.Fprintf(header_file, "#define is_%s_%s_ptr_zero_value is_%s_ptr_zero_value\n", package_name, decl_kind.type_name, list_type)
-					fmt.Fprintf(header_file, "#define %s_%s_ptr_as_JSON_ptr %s_ptr_as_JSON_ptr\n", package_name, decl_kind.type_name, list_type)
+					fmt.Fprintf(header_file, "#define      is_%s_%s_ptr_zero_value is_%s_ptr_zero_value\n", package_name, decl_kind.type_name, list_type)
+					fmt.Fprintf(header_file, "#define         %s_%s_ptr_as_JSON_ptr %s_ptr_as_JSON_ptr\n", package_name, decl_kind.type_name, list_type)
 					fmt.Fprintf(header_file, "#define JSON_as_%s_%s_ptr JSON_as_%s_ptr\n", package_name, decl_kind.type_name, list_type)
 					fmt.Fprintf(header_file, "\n")
 					struct_fields[list_type] = append(struct_fields[list_type], "count")
@@ -2019,7 +2019,10 @@ func print_type_declarations(
 									fmt.Fprintf(header_file, "    %s *items;\n", star_base_type)
 									fmt.Fprintf(header_file, "} %s;\n", list_type)
 									fmt.Fprintf(header_file, "\n")
-									fmt.Fprintf(header_file, "extern bool is_%[1]s_List_ptr_zero_value(const %[1]s_List *%[1]s_List_ptr);\n",
+									fmt.Fprintf(header_file, "#define make_empty_%s_List_array(n) (%[1]s_List *) calloc((n), sizeof (%[1]s_List))\n",
+										star_base_type)
+									fmt.Fprintf(header_file, "#define make_empty_%s_List() make_empty_%[1]s_List_array(1)\n", star_base_type)
+									fmt.Fprintf(header_file, "extern bool     is_%[1]s_List_ptr_zero_value(const %[1]s_List *%[1]s_List_ptr);\n",
 										star_base_type)
 									fmt.Fprintf(header_file, "\n")
 									struct_fields[list_type] = append(struct_fields[list_type], "count")
@@ -2094,8 +2097,7 @@ func print_type_declarations(
 								fmt.Fprintf(header_file, "    %s *items;\n", array_base_type)
 								fmt.Fprintf(header_file, "} %s;\n", list_type)
 								fmt.Fprintf(header_file, "\n")
-								fmt.Fprintf(header_file, "extern bool is_%[1]s_List_ptr_zero_value(const %[1]s_List *%[1]s_List_ptr);\n",
-									array_base_type)
+								fmt.Fprintf(header_file, "extern bool is_%[1]s_List_ptr_zero_value(const %[1]s_List *%[1]s_List_ptr);\n", array_base_type)
 								fmt.Fprintf(header_file, "\n")
 								struct_fields[list_type] = append(struct_fields[list_type], "count")
 								struct_fields[list_type] = append(struct_fields[list_type], "items")


### PR DESCRIPTION
In this update, we generate allocation-routine definitions for certain lists of items, to simplify the DataGeyser code that needs to dynamically allocate such lists.