### PR TITLE
GROUNDWORK-806 Reduce entropy consumption on TracerToken

### DIFF
--- a/cache/cache.go
+++ b/cache/cache.go
@@ -5,10 +5,16 @@ import (
 	"time"
 )
 
+// AuthCache used by Controller.validateToken
 var AuthCache = cache.New(8*time.Hour, time.Hour)
 
+// NatsCache used by NATS Dispatcher
 var NatsCache = cache.New(10*time.Minute, 10*time.Minute)
 
+// TraceTokenCache used by AgentService
+var TraceTokenCache = cache.New(-1, -1)
+
+// Credentials defines type of AuthCache items
 type Credentials struct {
 	GwosAppName  string
 	GwosAPIToken string


### PR DESCRIPTION
We don't need real random uuid for TracerToken. Instead we need some uniq id.
So, use random generator one time on application start. Then use increment.