### PR TITLE
GROUNDWORK-967: TCG identity api 

### DIFF
--- a/connectors/server-connector/serverConnector.go
+++ b/connectors/server-connector/serverConnector.go
@@ -579,9 +579,11 @@ type values struct {
 
 // Collects a map of process names to cpu usage, given a list of processes to be monitored
 func collectMonitoredProcesses(monitoredProcesses []transit.MetricDefinition) map[string]values {
-	hostProcesses, _ := process.Processes()
-
+	if len(monitoredProcesses) == 0 {
+		return make(map[string]values)
+	}
 	processes := make([]*localProcess, 0)
+	hostProcesses, _ := process.Processes()
 	for _, hostProcess := range hostProcesses {
 		cpuUsed, err := hostProcess.CPUPercent()
 		if err != nil {

--- a/services/controller.go
+++ b/services/controller.go
@@ -374,6 +374,21 @@ func (controller *Controller) stats(c *gin.Context) {
 }
 
 //
+// @Description The following API endpoint can be used to get a TCG agent id
+// @Tags    agent, connector
+// @Accept  json
+// @Produce json
+// @Success 200 {object} services.AgentStats
+// @Router  /agent [get]
+func (controller *Controller) agentIdentity(c *gin.Context) {
+	agentIdentity := AgentIdentity{
+		AgentID: controller.Stats().AgentID,
+		AppType: controller.Stats().AppType,
+	}
+	c.JSON(http.StatusOK, agentIdentity)
+}
+
+//
 // @Description The following API endpoint can be used to get TCG status.
 // @Tags    agent, connector
 // @Accept  json
@@ -434,6 +449,7 @@ func (controller *Controller) registerAPI1(router *gin.Engine, addr string, entr
 
 	apiV1Group := router.Group("/api/v1")
 	apiV1Config := router.Group("/api/v1/config")
+	apiV1Identity := router.Group("/api/v1/identity")
 	apiV1Group.Use(controller.validateToken)
 
 	apiV1Config.POST("", controller.config)
@@ -445,6 +461,7 @@ func (controller *Controller) registerAPI1(router *gin.Engine, addr string, entr
 	apiV1Group.POST("/stop", controller.stop)
 	apiV1Group.GET("/stats", controller.stats)
 	apiV1Group.GET("/status", controller.status)
+	apiV1Identity.GET("", controller.agentIdentity)
 
 	for _, entrypoint := range entrypoints {
 		switch entrypoint.Method {

--- a/services/services.go
+++ b/services/services.go
@@ -45,6 +45,11 @@ type AgentStats struct {
 	LastErrors             []string                           `json:"lastErrors"`
 }
 
+type AgentIdentity struct {
+	AgentID                string                             `json:"agentID"`
+	AppType                string                             `json:"appType"`
+}
+
 // AgentStatus defines TCG Agent status
 type AgentStatus struct {
 	Ctrl       *CtrlAction


### PR DESCRIPTION
identity api  introduced to pull agent id from pre-configured connectors

Usage:
GET /api/v1/identity

Example data in response:
{"agentID":"661e83e7-bb82-4fd5-9f7c-0b9ab13337f0","appType":"SERVER"}
