### PR TITLE
GROUNDWORK-1063: 

### DIFF
--- a/clients/dsClient.go
+++ b/clients/dsClient.go
@@ -62,7 +62,7 @@ func (client *DSClient) ValidateToken(appName, apiToken string, dalekServicesURL
 		"headers": headers,
 		"reqURL":  entrypoint.String(),
 	})
-	logEntryLevel := log.InfoLevel
+	logEntryLevel := log.DebugLevel
 	defer func() {
 		logEntry.Log(logEntryLevel, "DSClient: ValidateToken")
 	}()


### PR DESCRIPTION
use HTTPS to connect to Dalek Services when external connectors like Elastic