### PR TITLE
GROUNDWORK-1190 Improve libtransit Makefile for set build info

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -18,6 +18,9 @@ import (
 	"sync"
 )
 
+// Variables to control the build info
+// can be overridden by Go linker during the build step:
+// go build -ldflags "-X 'github.com/gwos/tcg/config.buildTag=<TAG>' -X 'github.com/gwos/tcg/config.buildTime=`date --rfc-3339=s`'"
 var (
 	buildTag  = "8.x.x"
 	buildTime = "Build time not provided"

--- a/libtransit/Makefile
+++ b/libtransit/Makefile
@@ -1,12 +1,33 @@
 # Makefile for libtransit/ files
 
-all	: libtransit.h libtransit.so
+# Define the build info used by Go linker
+BUILD_TAG           := ${BUILD_TAG}
+ifeq ($(BUILD_TAG),)
+    BUILD_TAG       := ${TRAVIS_TAG}
+endif
+ifeq ($(BUILD_TAG),)
+    BUILD_TAG       := ${COMMIT_HASH}
+endif
+ifeq ($(BUILD_TAG),)
+    BUILD_TAG       := 8.x
+endif
 
+BUILD_TIME          := ${BUILD_TIME}
+ifeq ($(BUILD_TIME),)
+    BUILD_TIME      := $$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+endif
+
+all	: echo libtransit.h libtransit.so
+
+echo:
+	@echo Build info: ${BUILD_TAG} / ${BUILD_TIME}
+
+# Build shared lib and set build info values with Go linker
 libtransit.h libtransit.so	: libtransit.go ../config/config.go ../milliseconds/milliseconds.go ../transit/*.go ../services/*.go ../log/*.go
-	    # go tool cgo [cgo options] [-- compiler options] libtransit.go
-	    # export GOPATH=${HOME}; go build -buildmode=c-shared -o libtransit.so libtransit.go
-	    go build -buildmode=c-shared -o libtransit.so libtransit.go
-	    chmod +x libtransit.so
+	go build \
+		-ldflags "-X 'github.com/gwos/tcg/config.buildTag=${BUILD_TAG}' -X 'github.com/gwos/tcg/config.buildTime=${BUILD_TIME}'" \
+		-buildmode=c-shared -o libtransit.so libtransit.go
+	chmod +x libtransit.so
 
 clean	:
 	rm -rf _obj libtransit.h libtransit.so


### PR DESCRIPTION
For today, there is the one procedure for `libtransit` and `connectors` to set the build info:
 update values of string variables in `config` package with Go linker at the build time.

And there is Makefile in `libtransit` folder for build shared lib and header files.
This Makefile is invoked from the repo top-level Makefile at the time of building the `nagios` docker image:
https://github.com/gwos/nagios/blob/master/Dockerfile#L184-L194
https://github.com/gwos/tcg/blob/master/Makefile#L111-L122

So, with this update the `nagios connector` will provide the build info for the Dalek UI as other connectors.