### PR TITLE
GROUNDWORK-1332: implemented connectors monitoring

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -80,9 +80,10 @@ func (l LogLevel) String() string {
 // Connector defines TCG Connector configuration
 // see GetConfig() for defaults
 type Connector struct {
-	AgentID string `yaml:"agentId"`
-	AppName string `yaml:"appName"`
-	AppType string `yaml:"appType"`
+	DisplayName string `yaml:"displayName"`
+	AgentID     string `yaml:"agentId"`
+	AppName     string `yaml:"appName"`
+	AppType     string `yaml:"appType"`
 	// ControllerAddr accepts value for combined "host:port"
 	// used as `http.Server{Addr}`
 	ControllerAddr     string `yaml:"controllerAddr"`
@@ -115,6 +116,7 @@ type Connector struct {
 
 // ConnectorDTO defines TCG Connector configuration
 type ConnectorDTO struct {
+	DisplayName   string        `json:"displayName"`
 	AgentID       string        `json:"agentId"`
 	AppName       string        `json:"appName"`
 	AppType       string        `json:"appType"`
@@ -354,6 +356,7 @@ func (cfg *Config) loadConnector(data []byte) (*ConnectorDTO, error) {
 		log.Error("|config.go| : [loadConnector] : ", err.Error())
 		return nil, err
 	}
+	cfg.Connector.DisplayName = dto.DisplayName
 	cfg.Connector.AgentID = dto.AgentID
 	cfg.Connector.AppName = dto.AppName
 	cfg.Connector.AppType = dto.AppType

--- a/connectors/apm-connector/apmConnector.go
+++ b/connectors/apm-connector/apmConnector.go
@@ -65,11 +65,12 @@ func (resource *Resource) UnmarshalJSON(input []byte) error {
 
 // ExtConfig defines the MonitorConnection extensions configuration
 type ExtConfig struct {
-	Groups        []transit.ResourceGroup   `json:"groups"`
-	Resources     []Resource                `json:"resources"`
-	Services      []string                  `json:"services"`
-	CheckInterval time.Duration             `json:"checkIntervalMinutes"`
-	Ownership     transit.HostOwnershipType `json:"ownership,omitempty"`
+	Groups           []transit.ResourceGroup   `json:"groups"`
+	Resources        []Resource                `json:"resources"`
+	Services         []string                  `json:"services"`
+	CheckInterval    time.Duration             `json:"checkIntervalMinutes"`
+	Ownership        transit.HostOwnershipType `json:"ownership,omitempty"`
+	MonitorConnector bool                      `json:"connectorMonitored"`
 }
 
 // UnmarshalJSON implements json.Unmarshaler.

--- a/connectors/apm-connector/main.go
+++ b/connectors/apm-connector/main.go
@@ -45,11 +45,12 @@ func configHandler(data []byte) {
 	log.Info("[APM Connector]: Configuration received")
 	/* Init config with default values */
 	tExt := &ExtConfig{
-		Groups:        []transit.ResourceGroup{},
-		Resources:     []Resource{},
-		Services:      []string{},
-		CheckInterval: connectors.DefaultCheckInterval,
-		Ownership:     transit.Yield,
+		Groups:           []transit.ResourceGroup{},
+		Resources:        []Resource{},
+		Services:         []string{},
+		CheckInterval:    connectors.DefaultCheckInterval,
+		Ownership:        transit.Yield,
+		MonitorConnector: false,
 	}
 	tMonConn := &transit.MonitorConnection{Extensions: tExt}
 	tMetProf := &transit.MetricsProfile{}
@@ -73,4 +74,12 @@ func configHandler(data []byte) {
 
 func periodicHandler() {
 	pull(extConfig.Resources)
+	if extConfig.MonitorConnector {
+		serviceName := transit.BuildConnectorServiceName(config.GetConfig().Connector.AppType,
+			config.GetConfig().Connector.DisplayName)
+		err := connectors.MonitorConnector(context.Background(), serviceName, true)
+		if err != nil {
+			log.Error("[APM Connector]: ", err)
+		}
+	}
 }

--- a/connectors/elastic-connector/elasticConnector.go
+++ b/connectors/elastic-connector/elasticConnector.go
@@ -49,6 +49,7 @@ type ExtConfig struct {
 	HostGroupField     string              `json:"hostGroupLabelPath"`
 	GroupNameByUser    bool                `json:"hostGroupNameByUser"`
 	CheckInterval      time.Duration       `json:"checkIntervalMinutes"`
+	MonitorConnector   bool                `json:"connectorMonitored"`
 	AppType            string
 	AgentID            string
 	GWConnections      config.GWConnections

--- a/connectors/elastic-connector/elasticConnectorModel.go
+++ b/connectors/elastic-connector/elasticConnectorModel.go
@@ -113,7 +113,7 @@ func (monitoringState *MonitoringState) toTransitResources() ([]transit.DynamicM
 	for _, host := range hosts {
 		monitoredServices, inventoryServices := host.toTransitResources(monitoringState.Metrics)
 
-		inventoryResource := connectors.CreateInventoryResource(host.name, inventoryServices)
+		inventoryResource := transit.CreateInventoryResource(host.name, inventoryServices)
 		irs[i] = inventoryResource
 
 		monitoredResource, err := connectors.CreateResource(host.name, monitoredServices)
@@ -140,7 +140,7 @@ func (host monitoringHost) toTransitResources(metricDefinitions map[string]trans
 		if metricDefinition, has := metricDefinitions[serviceName]; has {
 			customServiceName := connectors.Name(serviceName, metricDefinition.CustomName)
 
-			inventoryService := connectors.CreateInventoryService(customServiceName, host.name)
+			inventoryService := transit.CreateInventoryService(customServiceName, host.name)
 			inventoryServices[i] = inventoryService
 
 			metricBuilder := connectors.MetricBuilder{
@@ -181,11 +181,11 @@ func (monitoringState *MonitoringState) toResourceGroups() []transit.ResourceGro
 		monitoredResourceRefs := make([]transit.MonitoredResourceRef, len(hostsInGroup))
 		k := 0
 		for host := range hostsInGroup {
-			monitoredResourceRef := connectors.CreateMonitoredResourceRef(host, "", transit.Host)
+			monitoredResourceRef := transit.CreateMonitoredResourceRef(host, "", transit.Host)
 			monitoredResourceRefs[k] = monitoredResourceRef
 			k++
 		}
-		resourceGroup := connectors.CreateResourceGroup(group, group, transit.HostGroup, monitoredResourceRefs)
+		resourceGroup := transit.CreateResourceGroup(group, group, transit.HostGroup, monitoredResourceRefs)
 		rgs[j] = resourceGroup
 		j++
 	}

--- a/connectors/elastic-connector/main.go
+++ b/connectors/elastic-connector/main.go
@@ -71,6 +71,7 @@ func configHandler(data []byte) {
 		HostGroupField:     defaultHostGroupLabel,
 		GroupNameByUser:    defaultGroupNameByUser,
 		CheckInterval:      connectors.DefaultCheckInterval,
+		MonitorConnector:   false,
 		AppType:            config.GetConfig().Connector.AppType,
 		AgentID:            config.GetConfig().Connector.AgentID,
 		GWConnections:      config.GetConfig().GWConnections,
@@ -177,6 +178,14 @@ func periodicHandler() {
 		err := connectors.SendMetrics(context.Background(), metrics, nil)
 		if err != nil {
 			log.Error("[Elastic Connector]: ", err.Error())
+		}
+	}
+	if extConfig.MonitorConnector {
+		serviceName := transit.BuildConnectorServiceName(config.GetConfig().Connector.AppType,
+			config.GetConfig().Connector.DisplayName)
+		err := connectors.MonitorConnector(context.Background(), serviceName, true)
+		if err != nil {
+			log.Error("[Elastic Connector]: ", err)
 		}
 	}
 }

--- a/connectors/kubernetes-connector/kubernetesConnector.go
+++ b/connectors/kubernetes-connector/kubernetesConnector.go
@@ -149,10 +149,10 @@ func (connector *KubernetesConnector) Collect(cfg *ExtConfig) ([]transit.Dynamic
 		services := make([]transit.DynamicInventoryService, len(resource.Services))
 		serviceIndex := 0
 		for _, service := range resource.Services {
-			services[serviceIndex] = connectors.CreateInventoryService(service.Name, service.Owner)
+			services[serviceIndex] = transit.CreateInventoryService(service.Name, service.Owner)
 			serviceIndex = serviceIndex + 1
 		}
-		inventory[index] = connectors.CreateInventoryResource(resource.Name, services)
+		inventory[index] = transit.CreateInventoryResource(resource.Name, services)
 		// convert monitored state
 		mServices := make([]transit.DynamicMonitoredService, len(resource.Services))
 		serviceIndex = 0

--- a/connectors/server-connector/serverConnector.go
+++ b/connectors/server-connector/serverConnector.go
@@ -22,10 +22,11 @@ import (
 
 // ExtConfig defines the MonitorConnection extensions configuration
 type ExtConfig struct {
-	Groups        []transit.ResourceGroup   `json:"groups"`
-	Processes     []string                  `json:"processes"`
-	CheckInterval time.Duration             `json:"checkIntervalMinutes"`
-	Ownership     transit.HostOwnershipType `json:"ownership,omitempty"`
+	Groups           []transit.ResourceGroup   `json:"groups"`
+	Processes        []string                  `json:"processes"`
+	CheckInterval    time.Duration             `json:"checkIntervalMinutes"`
+	Ownership        transit.HostOwnershipType `json:"ownership,omitempty"`
+	MonitorConnector bool                      `json:"connectorMonitored"`
 }
 
 // UnmarshalJSON implements json.Unmarshaler.
@@ -74,6 +75,7 @@ var hostName string
 
 // temporary solution, will be removed
 var templateMetricName = "$view_Template#"
+
 const EnvTcgHostName = "TCG_HOST_NAME"
 
 // Synchronize inventory for necessary processes
@@ -98,12 +100,12 @@ func Synchronize(processes []transit.MetricDefinition) *transit.DynamicInventory
 		if pr.Name == templateMetricName {
 			continue
 		}
-		service := connectors.CreateInventoryService(connectors.Name(pr.Name, pr.CustomName),
+		service := transit.CreateInventoryService(connectors.Name(pr.Name, pr.CustomName),
 			hostName)
 		srvs = append(srvs, service)
 	}
 
-	inventoryResource := connectors.CreateInventoryResource(hostName, srvs)
+	inventoryResource := transit.CreateInventoryResource(hostName, srvs)
 
 	return &inventoryResource
 }

--- a/main.go
+++ b/main.go
@@ -38,10 +38,10 @@ func main() {
 	//                                Inventory Examples                                    //
 	//////////////////////////////////////////////////////////////////////////////////////////
 	var iServices []transit.DynamicInventoryService
-	is1 := connectors.CreateInventoryService(Service1, Resource1)
-	is2 := connectors.CreateInventoryService(Service2, Resource1)
+	is1 := transit.CreateInventoryService(Service1, Resource1)
+	is2 := transit.CreateInventoryService(Service2, Resource1)
 	iServices = append(iServices, is1, is2)
-	iResource1 := connectors.CreateInventoryResource(Resource1, iServices)
+	iResource1 := transit.CreateInventoryResource(Resource1, iServices)
 	println(iResource1.Services[0].Description)
 	println(iResource1.Description)
 	//if (enableTransit) {

--- a/services/agentService.go
+++ b/services/agentService.go
@@ -461,6 +461,10 @@ func (service *AgentService) makeDispatcherOptions() []nats.DispatcherOption {
 						_, err = gwClientRef.SynchronizeInventory(ctx, service.fixTracerContext(p.Payload))
 					case typeMetrics:
 						_, err = gwClientRef.SendResourcesWithMetrics(ctx, service.fixTracerContext(p.Payload))
+					case typeMonitorConnector:
+						_, err = gwClientRef.MonitorConnector(ctx, service.fixTracerContext(p.Payload))
+					case typeStopConnectorMonitoring:
+						_, err = gwClientRef.StopConnectorMonitoring(ctx, service.fixTracerContext(p.Payload))
 					default:
 						err = fmt.Errorf("dispatcher error on process payload type %s:%s", p.Type, subjInventoryMetrics)
 					}
@@ -613,9 +617,10 @@ func (service *AgentService) startTransport() error {
 	gwClients := make([]*clients.GWClient, len(cons))
 	for i := range cons {
 		gwClients[i] = &clients.GWClient{
-			AppName:      service.AppName,
-			AppType:      service.AppType,
-			GWConnection: cons[i],
+			ConnectorName: service.DisplayName,
+			AppName:       service.AppName,
+			AppType:       service.AppType,
+			GWConnection:  cons[i],
 		}
 	}
 	service.gwClients = gwClients

--- a/services/services.go
+++ b/services/services.go
@@ -115,6 +115,8 @@ type TransitServices interface {
 	SendEventsUnack(context.Context, []byte) error
 	SendResourceWithMetrics(context.Context, []byte) error
 	SynchronizeInventory(context.Context, []byte) error
+	MonitorConnector(context.Context, []byte) error
+	StopConnectorMonitoring(context.Context, []byte) error
 }
 
 // Controllers defines TCG Agent controllers interface
@@ -144,6 +146,8 @@ const (
 	typeEventsUnack
 	typeInventory
 	typeMetrics
+	typeMonitorConnector
+	typeStopConnectorMonitoring
 	typeClearInDowntime
 	typeSetInDowntime
 )

--- a/transit/transit.go
+++ b/transit/transit.go
@@ -6,6 +6,7 @@ import (
 	"github.com/gwos/tcg/log"
 	"github.com/gwos/tcg/milliseconds"
 	"strconv"
+	"strings"
 )
 
 // VersionString defines type of constant
@@ -150,6 +151,16 @@ const (
 	Critical                  = "Critical"
 	Min                       = "Min"
 	Max                       = "Max"
+)
+
+// Monitor Connectors constants
+const (
+	// TODO must be the same for tcg and cloudhub
+	TcgAlias                = "cloudhub"
+	SystemAppType           = "SYSTEM"
+	MonitorHostName         = "ConnectorMonitor"
+	ConnectorsHostGroup     = "Connectors"
+	ConnectorsHostGroupDesc = "Monitored CloudHub Connectors"
 )
 
 // TimeInterval defines a closed time interval. It extends from the start time
@@ -986,4 +997,57 @@ type HostsAndServices struct {
 	ServiceGroupCategoryNames []string `json:"serviceGroupCategoryNames"`
 	SetHosts                  bool     `json:"setHosts"`
 	SetServices               bool     `json:"setServices"`
+}
+
+// Inventory Constructors
+func CreateInventoryService(name string, owner string) DynamicInventoryService {
+	return DynamicInventoryService{
+		BaseTransitData: BaseTransitData{
+			Name:  name,
+			Type:  Service,
+			Owner: owner,
+		},
+	}
+}
+
+// makes and modifies a copy, doesn't modify services
+func CreateInventoryResource(name string, services []DynamicInventoryService) DynamicInventoryResource {
+	resource := DynamicInventoryResource{
+		BaseResource: BaseResource{
+			BaseTransitData: BaseTransitData{
+				Name: name,
+				Type: Host,
+			},
+		},
+	}
+	for _, s := range services {
+		resource.Services = append(resource.Services, s)
+	}
+	return resource
+}
+
+func CreateMonitoredResourceRef(name string, owner string, resourceType ResourceType) MonitoredResourceRef {
+	resource := MonitoredResourceRef{
+		Name:  name,
+		Type:  resourceType,
+		Owner: owner,
+	}
+	return resource
+}
+
+func CreateResourceGroup(name string, description string, groupType GroupType, resources []MonitoredResourceRef) ResourceGroup {
+	group := ResourceGroup{
+		GroupName:   name,
+		Type:        groupType,
+		Description: description,
+	}
+	for _, r := range resources {
+		group.Resources = append(group.Resources, r)
+	}
+	return group
+}
+
+func BuildConnectorServiceName(appType string, connectorName string) string {
+	connectorServiceName := appType + "-" + connectorName
+	return strings.ReplaceAll(connectorServiceName, " ", "_")
 }


### PR DESCRIPTION
On hold till Foundation ready

To discuss:
1. ConnectorMonitor in CH is being created under SYSTEM appType and "cloudhub" agentId. SYSTEM appType seems to be OK for TCG, but I left agentId="cloudhub" also so far as otherwise it caused ERROR log in Synchronizer that "same appType but different agents" which is really error case in our logic. I don't like too much that TCG creates services for its connectors with "cloudhub" owner, I'd like to find some agentId that can be shared between TCG and CH and won't contain project name in it, something like "connector_monitor", but we'll need a migration to update existing host and services owned by "cloudhub"
2. Process Stop/Remove connector