### PR TITLE
GW-1376-time-duration:  extend gotocjson to handle time.Duration fields

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,6 +21,10 @@ GENERIC_DATATYPES_BUILD_OBJECTS = \
 	${BUILD_TARGET_DIRECTORY}/generic_datatypes.c	\
 	${BUILD_TARGET_DIRECTORY}/generic_datatypes.h
 
+TIME_BUILD_OBJECTS = \
+	${BUILD_TARGET_DIRECTORY}/time.c	\
+	${BUILD_TARGET_DIRECTORY}/time.h
+
 CONFIG_BUILD_OBJECTS = \
 	${BUILD_TARGET_DIRECTORY}/config.c	\
 	${BUILD_TARGET_DIRECTORY}/config.h
@@ -53,6 +57,7 @@ LIBTRANSITJSON_LIBRARY = ${BUILD_TARGET_DIRECTORY}/libtransitjson.so
 BUILD_HEADER_FILES = \
 	${LIBTRANSIT_HEADER}				\
 	gotocjson/_c_code/convert_go_to_c.h		\
+	${BUILD_TARGET_DIRECTORY}/time.h		\
 	${BUILD_TARGET_DIRECTORY}/generic_datatypes.h	\
 	${BUILD_TARGET_DIRECTORY}/config.h		\
 	${BUILD_TARGET_DIRECTORY}/milliseconds.h	\
@@ -136,10 +141,13 @@ gotocjson/gotocjson	: gotocjson/gotocjson.go
 ${GENERIC_DATATYPES_BUILD_OBJECTS}	: gotocjson/gotocjson gotocjson/generic_datatypes/generic_datatypes.go | ${BUILD_TARGET_DIRECTORY}
 	gotocjson/gotocjson -g -o ${BUILD_TARGET_DIRECTORY} gotocjson/generic_datatypes/generic_datatypes.go
 
-${CONFIG_BUILD_OBJECTS}	: gotocjson/gotocjson config/config.go | ${BUILD_TARGET_DIRECTORY}
+${TIME_BUILD_OBJECTS}	: gotocjson/gotocjson time/time.go | ${BUILD_TARGET_DIRECTORY}
+	gotocjson/gotocjson -o ${BUILD_TARGET_DIRECTORY} time/time.go
+
+${CONFIG_BUILD_OBJECTS}	: gotocjson/gotocjson ${TIME_BUILD_OBJECTS} config/config.go | ${BUILD_TARGET_DIRECTORY}
 	gotocjson/gotocjson -o ${BUILD_TARGET_DIRECTORY} config/config.go
 
-${MILLISECONDS_BUILD_OBJECTS}	: gotocjson/gotocjson milliseconds/milliseconds.go | ${BUILD_TARGET_DIRECTORY}
+${MILLISECONDS_BUILD_OBJECTS}	: gotocjson/gotocjson ${TIME_BUILD_OBJECTS} milliseconds/milliseconds.go | ${BUILD_TARGET_DIRECTORY}
 	gotocjson/gotocjson -o ${BUILD_TARGET_DIRECTORY} milliseconds/milliseconds.go
 
 ${TRANSIT_BUILD_OBJECTS}	: gotocjson/gotocjson transit/transit.go | ${BUILD_TARGET_DIRECTORY}
@@ -151,10 +159,10 @@ ${BUILD_TARGET_DIRECTORY}/convert_go_to_c.o	: ${CONVERT_GO_TO_C_BUILD_OBJECTS} |
 ${BUILD_TARGET_DIRECTORY}/generic_datatypes.o	: ${GENERIC_DATATYPES_BUILD_OBJECTS}
 	${CC} -c ${BUILD_TARGET_DIRECTORY}/generic_datatypes.c -o $@ -Igotocjson/_c_code
 
-${BUILD_TARGET_DIRECTORY}/config.o	: ${CONFIG_BUILD_OBJECTS} ${BUILD_TARGET_DIRECTORY}/generic_datatypes.h
+${BUILD_TARGET_DIRECTORY}/config.o	: ${TIME_BUILD_OBJECTS} ${CONFIG_BUILD_OBJECTS} ${BUILD_TARGET_DIRECTORY}/generic_datatypes.h
 	${CC} -c ${BUILD_TARGET_DIRECTORY}/config.c -o $@ -Igotocjson/_c_code
 
-${BUILD_TARGET_DIRECTORY}/milliseconds.o	: ${MILLISECONDS_BUILD_OBJECTS} ${BUILD_TARGET_DIRECTORY}/generic_datatypes.h
+${BUILD_TARGET_DIRECTORY}/milliseconds.o	: ${TIME_BUILD_OBJECTS} ${MILLISECONDS_BUILD_OBJECTS} ${BUILD_TARGET_DIRECTORY}/generic_datatypes.h
 	${CC} -c ${BUILD_TARGET_DIRECTORY}/milliseconds.c -o $@ -Igotocjson/_c_code
 
 ${BUILD_TARGET_DIRECTORY}/transit.o	: ${TRANSIT_BUILD_OBJECTS} ${BUILD_TARGET_DIRECTORY}/generic_datatypes.h

--- a/time/time.go
+++ b/time/time.go
@@ -1,0 +1,36 @@
+// Copyright 2009 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Abridged copy of /usr/local/go/src/time/time.go, containing only the
+// parts potentially used for communication between Go and C code in TCG.
+//
+// There are several reasons for this abridgement.
+//
+// (*) We already have some special handling in place within the gotocjson
+//     conversion tool for the time.Time data structure.  That is done to
+//     support our gwos/milliseconds package, since the C implementation of
+//     that structure is not a direct analogue of the Go implementation.
+//     Including the actual time.Time data structure from time.go collides
+//     with that special handling.
+//
+// (*) The official time.go code includes two separate const blocks that both
+//     define sets of constants of type Duration.  Our gotocjson conversion
+//     tool presently treats those blocks as separate enumerations, and the C
+//     compiler objects to the collision of having two separate "enum Duration"
+//     declarations.  A future version of the conversion tool might consolidate
+//     such declarations, but that has not yet been done.
+//
+// (*) Our present application code as of this writing only needs a tiny part
+//     of the official time.go code with respect to what we address with our
+//     gotocjson tool.  So at least for the time being, there is insufficient
+//     cause to extend the tool to better address the items noted above.
+
+package time
+
+// A Duration represents the elapsed time between two instants
+// as an int64 nanosecond count. The representation limits the
+// largest representable duration to approximately 290 years.
+//
+type Duration int64
+


### PR DESCRIPTION
This commit allows Go struct fields to be declared as type time.Duration,
while generating correct conversion code in that case.  The tool has been
extended past that point in pursuit of processing the entire official
/usr/local/go/src/time/time.go file, but ultimately that was not possible.
Instead, we use a highly-abridged copy of that file, and that suffices
for current use against our application code.