### PR TITLE
Remove LogFileMaxAge setting

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -111,9 +111,8 @@ type Connector struct {
 	// if 0 turn off condensing
 	LogCondense time.Duration `yaml:"logCondense"`
 	// LogFile accepts file path to log in addition to stdout
-	LogFile        string        `yaml:"logFile"`
-	LogFileMaxAge  time.Duration `yaml:"logFileMaxAge"`
-	LogFileMaxSize int64         `yaml:"logFileMaxSize"`
+	LogFile        string `yaml:"logFile"`
+	LogFileMaxSize int64  `yaml:"logFileMaxSize"`
 	// Log files are rotated count times before being removed.
 	// If count is 0, old versions are removed rather than rotated.
 	LogFileRotate int      `yaml:"logFileRotate"`
@@ -341,8 +340,7 @@ func defaults() Config {
 			ControllerStartTimeout:  time.Duration(time.Second * 4),
 			ControllerStopTimeout:   time.Duration(time.Second * 4),
 			LogCondense:             0,
-			LogFileMaxAge:           time.Duration(time.Hour * 24 * 30), // 30days,
-			LogFileMaxSize:          1024 * 1024 * 10,                   // 10MB
+			LogFileMaxSize:          1024 * 1024 * 10, // 10MB
 			LogFileRotate:           5,
 			LogLevel:                1,
 			NatsAckWait:             time.Duration(time.Second * 30),
@@ -385,7 +383,6 @@ func GetConfig() *Config {
 
 		log.Config(
 			cfg.Connector.LogFile,
-			cfg.Connector.LogFileMaxAge,
 			cfg.Connector.LogFileMaxSize,
 			cfg.Connector.LogFileRotate,
 			int(cfg.Connector.LogLevel),
@@ -531,7 +528,6 @@ func (cfg *Config) LoadConnectorDTO(data []byte) (*ConnectorDTO, error) {
 	/* update logger */
 	log.Config(
 		cfg.Connector.LogFile,
-		cfg.Connector.LogFileMaxAge,
 		cfg.Connector.LogFileMaxSize,
 		cfg.Connector.LogFileRotate,
 		int(cfg.Connector.LogLevel),

--- a/log/log_test.go
+++ b/log/log_test.go
@@ -20,12 +20,12 @@ func TestConfig(t *testing.T) {
 
 	writerHook.cache = cache.New(10*time.Minute, 100*time.Millisecond)
 
-	Config(logFile1.Name(), 0, 0, 1, 3, 0)
+	Config(logFile1.Name(), 0, 1, 3, 0)
 	Debug("message debug1")
 	Info("message info1")
 	Warn("message warn1")
 
-	Config(logFile2.Name(), 0, 0, 1, 2, 200*time.Millisecond)
+	Config(logFile2.Name(), 0, 1, 2, 200*time.Millisecond)
 	Debug("message debug")
 	Info("message info")
 	Info("message info")
@@ -52,7 +52,7 @@ func TestLogrotate(t *testing.T) {
 	defer os.Remove(logFile.Name() + ".2")
 	defer os.Remove(logFile.Name() + ".3")
 
-	Config(logFile.Name(), 200*time.Millisecond, 140, 3, 3, 0)
+	Config(logFile.Name(), 140, 3, 3, 0)
 	Debug("message debug1")
 	Info("message info1")
 	Warn("message warn1") // expect rotation by maxSize
@@ -66,9 +66,10 @@ func TestLogrotate(t *testing.T) {
 	assert.Contains(t, string(log1), "debug1")
 
 	time.Sleep(200 * time.Millisecond)
-	Warn("message debug2") // expect rotation by maxAge
-	Warn("message info2")
-	Warn("message warn2") // expect rotation by maxSize
+	Debug("message debug2")
+	Info("message info2") // expect rotation by maxSize
+	Warn("message warn2")
+	Debug("message debug3") // expect rotation by maxSize
 
 	log0, elog0 = ioutil.ReadFile(logFile.Name())
 	log1, elog1 = ioutil.ReadFile(logFile.Name() + ".1")
@@ -78,18 +79,20 @@ func TestLogrotate(t *testing.T) {
 	assert.NoError(t, elog1)
 	assert.NoError(t, elog2)
 	assert.NoError(t, elog3)
+
 	assert.Contains(t, string(log3), "debug1")
 	assert.Contains(t, string(log3), "info1")
 	assert.Contains(t, string(log2), "warn1")
-	assert.Contains(t, string(log1), "debug2")
+	assert.Contains(t, string(log2), "debug2")
 	assert.Contains(t, string(log1), "info2")
-	assert.Contains(t, string(log0), "warn2")
+	assert.Contains(t, string(log1), "warn2")
+	assert.Contains(t, string(log0), "debug3")
 }
 
 func TestSanitizeEntries(t *testing.T) {
 	tmpFile, _ := ioutil.TempFile("", "log")
 	defer os.Remove(tmpFile.Name())
-	Config(tmpFile.Name(), 0, 0, 1, 3, 0)
+	Config(tmpFile.Name(), 0, 1, 3, 0)
 	payload1, _ := json.Marshal(struct{ Password, Token string }{
 		Password: `PASS
 		WORD`,


### PR DESCRIPTION
The current implementation depends on os stat syscall.
And it requires additional work to support this feature on different platforms.