### PR TITLE
GROUNDWORK-1664: Prometheus remote write

### DIFF
--- a/connectors/apm-connector/PromParser.go
+++ b/connectors/apm-connector/PromParser.go
@@ -1,8 +1,10 @@
 package main
 
 import (
+	"errors"
 	"fmt"
 	"github.com/gwos/tcg/log"
+	dto "github.com/prometheus/client_model/go"
 	"math"
 	"time"
 	//"github.com/influxdata/telegraf"
@@ -16,9 +18,26 @@ type PromParser struct {
 	DefaultTags map[string]string
 }
 
-func (p *PromParser) Parse(buf []byte) (interface{}, error) {
+func (p *PromParser) ParseDebug(buf []byte) (interface{}, error) {
+	var req prompb.WriteRequest
+	if err := proto.Unmarshal(buf, &req); err != nil {
+		return nil, fmt.Errorf("unable to unmarshal request body: %s", err)
+	}
+	for _, ts := range req.Timeseries {
+		println("----- time series ----")
+		for _, l := range ts.Labels {
+			fmt.Printf("\t%s = %s\n", l.GetName(), l.GetValue())
+		}
+		for _, s := range ts.Samples {
+			fmt.Printf("\t %f, %d\n", s.GetValue(), s.GetTimestamp())
+		}
+	}
+	return nil, errors.New("testing")
+}
+
+func (p *PromParser) Parse(buf []byte) (map[string]*dto.MetricFamily, error) {
 	var err error
-	var metrics []interface{}
+	var metrics = map[string]*dto.MetricFamily{}
 	var req prompb.WriteRequest
 
 	if err := proto.Unmarshal(buf, &req); err != nil {
@@ -28,13 +47,16 @@ func (p *PromParser) Parse(buf []byte) (interface{}, error) {
 	now := time.Now()
 
 	for _, ts := range req.Timeseries {
+
 		tags := map[string]string{}
 		for key, value := range p.DefaultTags {
 			tags[key] = value
 		}
 
-		for _, l := range ts.Labels {
+		labels := make([]*dto.LabelPair, 0)
+	 	for _, l := range ts.Labels {
 			tags[l.Name] = l.Value
+			labels = append(labels, &dto.LabelPair{Name: &l.Name, Value: &l.Value})
 		}
 
 		metricName := tags[model.MetricNameLabel]
@@ -43,21 +65,32 @@ func (p *PromParser) Parse(buf []byte) (interface{}, error) {
 		}
 		delete(tags, model.MetricNameLabel)
 
+		mf, ok := metrics[metricName]
+		if !ok {
+			mf = &dto.MetricFamily{
+				Name:   &metricName,
+				Type:   dto.MetricType_COUNTER.Enum(),
+				Metric: make([]*dto.Metric, 0),
+			}
+			metrics[metricName] = mf
+		}
 		for _, s := range ts.Samples {
-			fields := make(map[string]interface{})
-			if !math.IsNaN(s.Value) {
-				fields[metricName] = s.Value
+			stamp := now.Unix()
+			if s.Timestamp > 0 {
+				stamp = s.Timestamp // time.Unix(0, s.Timestamp*1000000)
 			}
-			// converting to telegraf metric
-			if len(fields) > 0 {
-				t := now
-				if s.Timestamp > 0 {
-					t = time.Unix(0, s.Timestamp*1000000)
-				}
-b				log.Debug(t)
-				// metric.New("prometheus_remote_write", tags, fields, t)
-				// metrics = append(metrics, m)
+			if math.IsNaN(s.Value) {
+				log.Error("Nan Value ignored for ", metricName)
+				continue
 			}
+			m := dto.Metric{
+				Label: labels,
+				Counter: &dto.Counter{
+					Value: &s.Value,
+				},
+				TimestampMs: &stamp,
+			}
+			mf.Metric = append(mf.Metric, &m)
 		}
 	}
 	return metrics, err

--- a/connectors/apm-connector/PromParser.go
+++ b/connectors/apm-connector/PromParser.go
@@ -1,38 +1,19 @@
 package main
 
 import (
-	"errors"
 	"fmt"
-	"github.com/gwos/tcg/log"
-	dto "github.com/prometheus/client_model/go"
-	"math"
-	"time"
-	//"github.com/influxdata/telegraf"
-	//"github.com/influxdata/telegraf/metric"
 	"github.com/gogo/protobuf/proto"
+	"github.com/gwos/tcg/log"
+	"github.com/pkg/errors"
+	dto "github.com/prometheus/client_model/go"
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/prompb"
+	"math"
+	"time"
 )
 
 type PromParser struct {
 	DefaultTags map[string]string
-}
-
-func (p *PromParser) ParseDebug(buf []byte) (interface{}, error) {
-	var req prompb.WriteRequest
-	if err := proto.Unmarshal(buf, &req); err != nil {
-		return nil, fmt.Errorf("unable to unmarshal request body: %s", err)
-	}
-	for _, ts := range req.Timeseries {
-		println("----- time series ----")
-		for _, l := range ts.Labels {
-			fmt.Printf("\t%s = %s\n", l.GetName(), l.GetValue())
-		}
-		for _, s := range ts.Samples {
-			fmt.Printf("\t %f, %d\n", s.GetValue(), s.GetTimestamp())
-		}
-	}
-	return nil, errors.New("testing")
 }
 
 func (p *PromParser) Parse(buf []byte) (map[string]*dto.MetricFamily, error) {
@@ -96,23 +77,20 @@ func (p *PromParser) Parse(buf []byte) (map[string]*dto.MetricFamily, error) {
 	return metrics, err
 }
 
-//func (p *Parser) ParseLine(line string) (telegraf.Metric, error) {
-//	metrics, err := p.Parse([]byte(line))
-//	if err != nil {
-//		return nil, err
-//	}
-//
-//	if len(metrics) < 1 {
-//		return nil, fmt.Errorf("No metrics in line")
-//	}
-//
-//	if len(metrics) > 1 {
-//		return nil, fmt.Errorf("More than one metric in line")
-//	}
-//
-//	return metrics[0], nil
-//}
-//
-//func (p *Parser) SetDefaultTags(tags map[string]string) {
-//	p.DefaultTags = tags
-//}
+func (p *PromParser) parseDebug(buf []byte) (interface{}, error) {
+	var req prompb.WriteRequest
+	if err := proto.Unmarshal(buf, &req); err != nil {
+		return nil, fmt.Errorf("unable to unmarshal request body: %s", err)
+	}
+	for _, ts := range req.Timeseries {
+		println("----- time series ----")
+		for _, l := range ts.Labels {
+			fmt.Printf("\t%s = %s\n", l.GetName(), l.GetValue())
+		}
+		for _, s := range ts.Samples {
+			fmt.Printf("\t %f, %d\n", s.GetValue(), s.GetTimestamp())
+		}
+	}
+	return nil, errors.New("testing")
+}
+

--- a/connectors/apm-connector/PromParser.go
+++ b/connectors/apm-connector/PromParser.go
@@ -1,0 +1,85 @@
+package main
+
+import (
+	"fmt"
+	"github.com/gwos/tcg/log"
+	"math"
+	"time"
+	//"github.com/influxdata/telegraf"
+	//"github.com/influxdata/telegraf/metric"
+	"github.com/gogo/protobuf/proto"
+	"github.com/prometheus/common/model"
+	"github.com/prometheus/prometheus/prompb"
+)
+
+type PromParser struct {
+	DefaultTags map[string]string
+}
+
+func (p *PromParser) Parse(buf []byte) (interface{}, error) {
+	var err error
+	var metrics []interface{}
+	var req prompb.WriteRequest
+
+	if err := proto.Unmarshal(buf, &req); err != nil {
+		return nil, fmt.Errorf("unable to unmarshal request body: %s", err)
+	}
+
+	now := time.Now()
+
+	for _, ts := range req.Timeseries {
+		tags := map[string]string{}
+		for key, value := range p.DefaultTags {
+			tags[key] = value
+		}
+
+		for _, l := range ts.Labels {
+			tags[l.Name] = l.Value
+		}
+
+		metricName := tags[model.MetricNameLabel]
+		if metricName == "" {
+			return nil, fmt.Errorf("metric name %q not found in tag-set or empty", model.MetricNameLabel)
+		}
+		delete(tags, model.MetricNameLabel)
+
+		for _, s := range ts.Samples {
+			fields := make(map[string]interface{})
+			if !math.IsNaN(s.Value) {
+				fields[metricName] = s.Value
+			}
+			// converting to telegraf metric
+			if len(fields) > 0 {
+				t := now
+				if s.Timestamp > 0 {
+					t = time.Unix(0, s.Timestamp*1000000)
+				}
+b				log.Debug(t)
+				// metric.New("prometheus_remote_write", tags, fields, t)
+				// metrics = append(metrics, m)
+			}
+		}
+	}
+	return metrics, err
+}
+
+//func (p *Parser) ParseLine(line string) (telegraf.Metric, error) {
+//	metrics, err := p.Parse([]byte(line))
+//	if err != nil {
+//		return nil, err
+//	}
+//
+//	if len(metrics) < 1 {
+//		return nil, fmt.Errorf("No metrics in line")
+//	}
+//
+//	if len(metrics) > 1 {
+//		return nil, fmt.Errorf("More than one metric in line")
+//	}
+//
+//	return metrics[0], nil
+//}
+//
+//func (p *Parser) SetDefaultTags(tags map[string]string) {
+//	p.DefaultTags = tags
+//}

--- a/connectors/apm-connector/apmConnector.go
+++ b/connectors/apm-connector/apmConnector.go
@@ -1,10 +1,14 @@
 package main
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
+	"github.com/golang/snappy"
+	"github.com/prometheus/common/model"
+	"io"
 	"net/http"
 	"sort"
 	"strconv"
@@ -89,8 +93,50 @@ func (cfg *ExtConfig) UnmarshalJSON(input []byte) error {
 const defaultHostName = "APM-Host"
 const defaultHostGroupName = "Servers"
 
-func parsePrometheusBody(body []byte, resourceIndex int) (*[]transit.DynamicMonitoredResource, *[]transit.ResourceGroup, error) {
+func parsePrometheusBody(body []byte, resourceIndex int, isProtobuf bool) (*[]transit.DynamicMonitoredResource, *[]transit.ResourceGroup, error) {
+	//decc := &SampleDecoder{
+	//	Dec: &protoDecoder{r: strings.NewReader(body)},
+	//	Opts: &DecodeOptions{
+	//		Timestamp: testTime,
+	//	},
+	//}
+
+	//writer := bytes.NewBufferString("your string")
+	//w, err := expfmt.MetricFamilyToOpenMetrics(writer, body.(dto.MetricFamilys))
+	//log.Error(w)
 	var parser expfmt.TextParser
+	if isProtobuf {
+ 		// reader := bytes.NewReader(body)
+		dest := make([]byte, len(body))
+		dst, err := snappy.Decode(dest, body)
+		if err != nil {
+			return nil, nil, err
+		}
+		r := bytes.NewReader(dst)
+ 		// r := strings.NewReader(s)
+		dec := expfmt.NewDecoder(r, expfmt.FmtProtoDelim)
+		//  log.Error("body: [", s, "]")
+
+		//mf := dto.MetricFamily{}
+		//err := dec.Decode(&mf)
+		//log.Error(err)
+	 	decoder := expfmt.SampleDecoder{
+			Dec:  dec,
+			Opts: &expfmt.DecodeOptions{},
+		}
+		for {
+			var v model.Vector
+			if err := decoder.Decode(&v); err != nil {
+				if err == io.EOF {
+					// Expected loop termination condition.
+					break
+				}
+				log.Error("Invalid Decode. Skipping.")
+				continue
+				}
+		}
+ 		return nil, nil, errors.New("testing ...")
+	}
 	prometheusServices, err := parser.TextToMetricFamilies(strings.NewReader(string(body)))
 	if err != nil {
 		return nil, nil, err
@@ -105,8 +151,8 @@ func parsePrometheusBody(body []byte, resourceIndex int) (*[]transit.DynamicMoni
 	return monitoredResources, &resourceGroups, nil
 }
 
-func processMetrics(body []byte, resourceIndex int, statusDown bool) error {
-	if monitoredResources, resourceGroups, err := parsePrometheusBody(body, resourceIndex); err == nil {
+func  processMetrics(body []byte, resourceIndex int, statusDown bool, isProtobuf bool) error {
+	if monitoredResources, resourceGroups, err := parsePrometheusBody(body, resourceIndex, isProtobuf); err == nil {
 		if statusDown {
 			for i := 0; i < len(*monitoredResources); i++ {
 				(*monitoredResources)[i].Status = transit.HostUnscheduledDown
@@ -370,13 +416,18 @@ func initializeEntrypoints() []services.Entrypoint {
 }
 
 func receiverHandler(c *gin.Context) {
+	log.Error("content type = ", c.GetHeader("Content-Type"))
 	body, err := c.GetRawData()
+	if len(body) < 2 {
+		log.Info("Received Prometheus Push heartbeat...")
+	}
 	if err != nil {
 		log.Error("|apmConnector.go| : [receiverHandler] : ", err)
 		c.JSON(http.StatusBadRequest, err.Error())
 		return
 	}
-	err = processMetrics(body, -1, false)
+	isProtobuf := c.GetHeader("Content-Type") == "application/x-protobuf"
+	err = processMetrics(body, -1, false, isProtobuf)
 	if err != nil {
 		log.Error(fmt.Sprintf("[APM Connector]~[Push]: %s", err))
 	}
@@ -396,7 +447,7 @@ func pull(resources []Resource) {
 				resource.URL, string(byteResponse)))
 			continue
 		}
-		err = processMetrics(byteResponse, index, statusCode == 220)
+		err = processMetrics(byteResponse, index, statusCode == 220, false				)
 		if err != nil {
 			log.Error(fmt.Sprintf("[APM Connector]~[Pull]: %s", err))
 		}

--- a/connectors/apm-connector/apmConnector.go
+++ b/connectors/apm-connector/apmConnector.go
@@ -424,38 +424,3 @@ func pull(resources []Resource) {
 		}
 	}
 }
-
-//decc := &SampleDecoder{
-//	Dec: &protoDecoder{r: strings.NewReader(body)},
-//	Opts: &DecodeOptions{
-//		Timestamp: testTime,
-//	},
-//}
-
-//writer := bytes.NewBufferString("your string")
-//w, err := expfmt.MetricFamilyToOpenMetrics(writer, body.(dto.MetricFamilys))
-//log.Error(w)
-
-//r := bytes.NewReader(dst)
-//// r := strings.NewReader(s)
-//dec := expfmt.NewDecoder(r, expfmt.FmtProtoDelim)
-////  log.Error("body: [", s, "]")
-//
-////mf := dto.MetricFamily{}
-////err := dec.Decode(&mf)
-////log.Error(err)
-//decoder := expfmt.SampleDecoder{
-//	Dec:  dec,
-//	Opts: &expfmt.DecodeOptions{},
-//}
-//for {
-//	var v model.Vector
-//	if err := decoder.Decode(&v); err != nil {
-//		if err == io.EOF {
-//			// Expected loop termination condition.
-//			break
-//		}
-//		log.Error("Invalid Decode. Skipping.")
-//		continue
-//		}
-//}

--- a/connectors/apm-connector/apmConnector.go
+++ b/connectors/apm-connector/apmConnector.go
@@ -95,7 +95,7 @@ func parsePrometheusBody(body []byte, resourceIndex int, isProtobuf bool) (*[]tr
 	var promParser PromParser
 	var prometheusServices map[string]*dto.MetricFamily
 	if isProtobuf {
- 		// reader := bytes.NewReader(body)
+		// reader := bytes.NewReader(body)
 		dest := make([]byte, len(body))
 		dst, err := snappy.Decode(dest, body)
 		if err != nil {
@@ -121,8 +121,7 @@ func parsePrometheusBody(body []byte, resourceIndex int, isProtobuf bool) (*[]tr
 	return monitoredResources, &resourceGroups, nil
 }
 
-
-func  processMetrics(body []byte, resourceIndex int, statusDown bool, isProtobuf bool) error {
+func processMetrics(body []byte, resourceIndex int, statusDown bool, isProtobuf bool) error {
 	if monitoredResources, resourceGroups, err := parsePrometheusBody(body, resourceIndex, isProtobuf); err == nil {
 		if statusDown {
 			for i := 0; i < len(*monitoredResources); i++ {
@@ -153,7 +152,7 @@ func makeValue(serviceName string, metricType *dto.MetricType, metric *dto.Metri
 		result[serviceName] = metric.GetCounter().GetValue()
 	case dto.MetricType_UNTYPED:
 		result[serviceName] = metric.GetUntyped().GetValue()
-		case dto.MetricType_GAUGE:
+	case dto.MetricType_GAUGE:
 		result[serviceName] = metric.GetGauge().GetValue()
 	case dto.MetricType_HISTOGRAM:
 		if metric.GetHistogram().SampleSum != nil {
@@ -418,7 +417,7 @@ func pull(resources []Resource) {
 				resource.URL, string(byteResponse)))
 			continue
 		}
-		err = processMetrics(byteResponse, index, statusCode == 220, false				)
+		err = processMetrics(byteResponse, index, statusCode == 220, false)
 		if err != nil {
 			log.Error(fmt.Sprintf("[APM Connector]~[Pull]: %s", err))
 		}

--- a/connectors/apm-connector/apmConnector.go
+++ b/connectors/apm-connector/apmConnector.go
@@ -1,14 +1,11 @@
 package main
 
 import (
-	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"github.com/golang/snappy"
-	"github.com/prometheus/common/model"
-	"io"
 	"net/http"
 	"sort"
 	"strconv"
@@ -112,29 +109,35 @@ func parsePrometheusBody(body []byte, resourceIndex int, isProtobuf bool) (*[]tr
 		if err != nil {
 			return nil, nil, err
 		}
-		r := bytes.NewReader(dst)
- 		// r := strings.NewReader(s)
-		dec := expfmt.NewDecoder(r, expfmt.FmtProtoDelim)
-		//  log.Error("body: [", s, "]")
 
-		//mf := dto.MetricFamily{}
-		//err := dec.Decode(&mf)
-		//log.Error(err)
-	 	decoder := expfmt.SampleDecoder{
-			Dec:  dec,
-			Opts: &expfmt.DecodeOptions{},
-		}
-		for {
-			var v model.Vector
-			if err := decoder.Decode(&v); err != nil {
-				if err == io.EOF {
-					// Expected loop termination condition.
-					break
-				}
-				log.Error("Invalid Decode. Skipping.")
-				continue
-				}
-		}
+		var pp PromParser
+		result, error := pp.Parse(dst)
+		log.Error(result)
+		log.Error(error)
+
+		//r := bytes.NewReader(dst)
+ 		//// r := strings.NewReader(s)
+		//dec := expfmt.NewDecoder(r, expfmt.FmtProtoDelim)
+		////  log.Error("body: [", s, "]")
+		//
+		////mf := dto.MetricFamily{}
+		////err := dec.Decode(&mf)
+		////log.Error(err)
+	 	//decoder := expfmt.SampleDecoder{
+		//	Dec:  dec,
+		//	Opts: &expfmt.DecodeOptions{},
+		//}
+		//for {
+		//	var v model.Vector
+		//	if err := decoder.Decode(&v); err != nil {
+		//		if err == io.EOF {
+		//			// Expected loop termination condition.
+		//			break
+		//		}
+		//		log.Error("Invalid Decode. Skipping.")
+		//		continue
+		//		}
+		//}
  		return nil, nil, errors.New("testing ...")
 	}
 	prometheusServices, err := parser.TextToMetricFamilies(strings.NewReader(string(body)))

--- a/connectors/apm-connector/promParser.go
+++ b/connectors/apm-connector/promParser.go
@@ -35,7 +35,7 @@ func (p *PromParser) Parse(buf []byte) (map[string]*dto.MetricFamily, error) {
 		}
 
 		labels := make([]*dto.LabelPair, 0)
-	 	for _, l := range ts.Labels {
+		for _, l := range ts.Labels {
 			tags[l.Name] = l.Value
 			labels = append(labels, &dto.LabelPair{Name: &l.Name, Value: &l.Value})
 		}
@@ -83,14 +83,13 @@ func (p *PromParser) parseDebug(buf []byte) (interface{}, error) {
 		return nil, fmt.Errorf("unable to unmarshal request body: %s", err)
 	}
 	for _, ts := range req.Timeseries {
-		println("----- time series ----")
+		log.Debug("----- time series ----")
 		for _, l := range ts.Labels {
-			fmt.Printf("\t%s = %s\n", l.GetName(), l.GetValue())
+			log.Debug(fmt.Sprintf("\t%s = %s\n", l.GetName(), l.GetValue()))
 		}
 		for _, s := range ts.Samples {
-			fmt.Printf("\t %f, %d\n", s.GetValue(), s.GetTimestamp())
+			log.Debug(fmt.Sprintf("\t %f, %d\n", s.GetValue(), s.GetTimestamp()))
 		}
 	}
 	return nil, errors.New("testing")
 }
-

--- a/go.mod
+++ b/go.mod
@@ -14,8 +14,11 @@ require (
 	github.com/gin-gonic/gin v1.7.2
 	github.com/go-ole/go-ole v1.2.5 // indirect
 	github.com/go-openapi/spec v0.20.3 // indirect
+	github.com/gogo/protobuf v1.3.2 // indirect
+	github.com/golang/snappy v0.0.3
 	github.com/gorilla/sessions v1.2.1 // indirect
 	github.com/gosnmp/gosnmp v1.32.0
+	github.com/grpc-ecosystem/grpc-gateway v1.16.0 // indirect
 	github.com/hashicorp/go-immutable-radix v1.3.0 // indirect
 	github.com/hashicorp/go-uuid v1.0.2
 	github.com/hashicorp/golang-lru v0.5.4 // indirect
@@ -29,10 +32,10 @@ require (
 	github.com/prometheus/client_golang v1.11.0
 	github.com/prometheus/client_model v0.2.0
 	github.com/prometheus/common v0.29.0
+	github.com/prometheus/prometheus v2.5.0+incompatible // indirect
 	github.com/robfig/cron/v3 v3.0.1
 	github.com/shirou/gopsutil v3.21.5+incompatible
 	github.com/sirupsen/logrus v1.8.1
-	github.com/golang/snappy v0.0.3
 	github.com/stretchr/testify v1.7.0
 	github.com/swaggo/gin-swagger v1.3.0
 	github.com/swaggo/swag v1.7.0

--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/gin-gonic/gin v1.7.2
 	github.com/go-ole/go-ole v1.2.5 // indirect
 	github.com/go-openapi/spec v0.20.3 // indirect
-	github.com/gogo/protobuf v1.3.2 // indirect
+	github.com/gogo/protobuf v1.3.2
 	github.com/golang/snappy v0.0.3
 	github.com/gorilla/sessions v1.2.1 // indirect
 	github.com/gosnmp/gosnmp v1.32.0
@@ -29,10 +29,11 @@ require (
 	github.com/nats-io/nats-streaming-server v0.22.0
 	github.com/nats-io/stan.go v0.9.0
 	github.com/patrickmn/go-cache v2.1.0+incompatible
+	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.11.0
 	github.com/prometheus/client_model v0.2.0
 	github.com/prometheus/common v0.29.0
-	github.com/prometheus/prometheus v2.5.0+incompatible // indirect
+	github.com/prometheus/prometheus v2.5.0+incompatible
 	github.com/robfig/cron/v3 v3.0.1
 	github.com/shirou/gopsutil v3.21.5+incompatible
 	github.com/sirupsen/logrus v1.8.1

--- a/go.mod
+++ b/go.mod
@@ -32,6 +32,7 @@ require (
 	github.com/robfig/cron/v3 v3.0.1
 	github.com/shirou/gopsutil v3.21.5+incompatible
 	github.com/sirupsen/logrus v1.8.1
+	github.com/golang/snappy v0.0.3
 	github.com/stretchr/testify v1.7.0
 	github.com/swaggo/gin-swagger v1.3.0
 	github.com/swaggo/swag v1.7.0

--- a/go.sum
+++ b/go.sum
@@ -195,6 +195,8 @@ github.com/golang/protobuf v1.4.1/go.mod h1:U8fpvMrcmy5pZrNK1lt4xCsGvpyWQ/VVv6QD
 github.com/golang/protobuf v1.4.2/go.mod h1:oDoupMAO8OvCJWAcko0GGGIgR6R6ocIYbsSw735rRwI=
 github.com/golang/protobuf v1.4.3 h1:JjCZWpVbqXDqFVmTfYWEVTMIYrL/NPdPSCHPJ0T/raM=
 github.com/golang/protobuf v1.4.3/go.mod h1:oDoupMAO8OvCJWAcko0GGGIgR6R6ocIYbsSw735rRwI=
+github.com/golang/snappy v0.0.3 h1:fHPg5GQYlCeLIPB9BZqMVR5nR9A+IM5zcgeTdjMYmLA=
+github.com/golang/snappy v0.0.3/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=
 github.com/gomodule/redigo v2.0.0+incompatible h1:K/R+8tc58AaqLkqG2Ol3Qk+DR/TlNuhuh457pBFPtt0=
 github.com/gomodule/redigo v2.0.0+incompatible/go.mod h1:B4C85qUVwatsJoIUNIfCRsp7qO0iAmpGFZ4EELWSbC4=
 github.com/google/btree v0.0.0-20180813153112-4030bb1f1f0c/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ5JPQ=

--- a/go.sum
+++ b/go.sum
@@ -365,6 +365,7 @@ github.com/patrickmn/go-cache v2.1.0+incompatible/go.mod h1:3Qf8kWWT7OJRJbdiICTK
 github.com/peterbourgon/diskv v2.0.1+incompatible/go.mod h1:uqqh8zWWbv1HBMNONnaR/tNboyR3/BZd58JJSHlUSCU=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
+github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=

--- a/go.sum
+++ b/go.sum
@@ -62,6 +62,7 @@ github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751/go.mod h1:LOuy
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
 github.com/alecthomas/units v0.0.0-20190717042225-c3de453c63f4/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
 github.com/alecthomas/units v0.0.0-20190924025748-f65c72e2690d/go.mod h1:rBZYJk541a8SKzHPHnH3zbiI+7dagKZ0cgpgrD7Fyho=
+github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kdvxnR2qWY=
 github.com/armon/go-metrics v0.0.0-20190430140413-ec5e00d3c878/go.mod h1:3AMJUQhVx52RsWOnlkpikZr01T/yAVN2gn0861vByNg=
 github.com/armon/go-metrics v0.3.8 h1:oOxq3KPj0WhCuy50EhzwiyMyG2ovRQZpZLXQuOh2a/M=
 github.com/armon/go-metrics v0.3.8/go.mod h1:4O98XIr/9W0sxpJ8UaYkvjk10Iff7SnFrb4QAOwNTFc=
@@ -242,6 +243,8 @@ github.com/gorilla/websocket v1.4.2/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/ad
 github.com/gosnmp/gosnmp v1.32.0 h1:gctewmZx5qFI0oHMzRnjETqIZ093d9NgZy9TQr3V0iA=
 github.com/gosnmp/gosnmp v1.32.0/go.mod h1:EIp+qkEpXoVsyZxXKy0AmXQx0mCHMMcIhXXvNDMpgF0=
 github.com/gregjones/httpcache v0.0.0-20180305231024-9cad4c3443a7/go.mod h1:FecbI9+v66THATjSRHfNgh1IVFe/9kFxbXtjV0ctIMA=
+github.com/grpc-ecosystem/grpc-gateway v1.16.0 h1:gmcG1KaJ57LophUzW0Hy8NmPhnMZb4M0+kPpLofRdBo=
+github.com/grpc-ecosystem/grpc-gateway v1.16.0/go.mod h1:BDjrQk3hbvj6Nolgz8mAMFbcEtjT1g+wF4CSlocrBnw=
 github.com/hashicorp/go-cleanhttp v0.5.0/go.mod h1:JpRdi6/HCYpAwUzNwuwqhbovhLtngrth3wmdIIUrZ80=
 github.com/hashicorp/go-hclog v0.9.1/go.mod h1:5CU+agLiy3J7N7QjHK5d05KxGsuXiQLrjA0H7acj2lQ=
 github.com/hashicorp/go-hclog v0.16.1 h1:IVQwpTGNRRIHafnTs2dQLIk4ENtneRIEEJWOVDqz99o=
@@ -391,8 +394,11 @@ github.com/prometheus/procfs v0.0.8/go.mod h1:7Qr8sr6344vo1JqZ6HhLceV9o3AJ1Ff+Gx
 github.com/prometheus/procfs v0.1.3/go.mod h1:lV6e/gmhEcM9IjHGsFOCxxuZ+z1YqCvr4OA4YeYWdaU=
 github.com/prometheus/procfs v0.6.0 h1:mxy4L2jP6qMonqmq+aTtOx1ifVWUgG/TAmntgbh3xv4=
 github.com/prometheus/procfs v0.6.0/go.mod h1:cz+aTbrPOrUb4q7XlbU9ygM+/jj0fzG6c1xBZuNvfVA=
+github.com/prometheus/prometheus v2.5.0+incompatible h1:7QPitgO2kOFG8ecuRn9O/4L9+10He72rVRJvMXrE9Hg=
+github.com/prometheus/prometheus v2.5.0+incompatible/go.mod h1:oAIUtOny2rjMX0OWN5vPR5/q/twIROJvdqnQKDdil/s=
 github.com/robfig/cron/v3 v3.0.1 h1:WdRxkvbJztn8LMz/QEvLN5sBU+xKpSqwwUO1Pjr4qDs=
 github.com/robfig/cron/v3 v3.0.1/go.mod h1:eQICP3HwyT7UooqI/z+Ov+PtYAWygg1TEWWzGIFLtro=
+github.com/rogpeppe/fastuuid v1.2.0/go.mod h1:jVj6XXZzXRy/MSR5jhDC/2q6DgLz+nrA6LYCDYWNEvQ=
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
 github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/shirou/gopsutil v3.21.5+incompatible h1:OloQyEerMi7JUrXiNzy8wQ5XN+baemxSl12QgIzt0jc=
@@ -743,11 +749,13 @@ google.golang.org/genproto v0.0.0-20200312145019-da6875a35672/go.mod h1:55QSHmfG
 google.golang.org/genproto v0.0.0-20200331122359-1ee6d9798940/go.mod h1:55QSHmfGQM9UVYDPBsyGGes0y52j32PQ3BqQfXhyH3c=
 google.golang.org/genproto v0.0.0-20200430143042-b979b6f78d84/go.mod h1:55QSHmfGQM9UVYDPBsyGGes0y52j32PQ3BqQfXhyH3c=
 google.golang.org/genproto v0.0.0-20200511104702-f5ebc3bea380/go.mod h1:55QSHmfGQM9UVYDPBsyGGes0y52j32PQ3BqQfXhyH3c=
+google.golang.org/genproto v0.0.0-20200513103714-09dca8ec2884/go.mod h1:55QSHmfGQM9UVYDPBsyGGes0y52j32PQ3BqQfXhyH3c=
 google.golang.org/genproto v0.0.0-20200515170657-fc4c6c6a6587/go.mod h1:YsZOwe1myG/8QRHRsmBRE1LrgQY60beZKjly0O1fX9U=
 google.golang.org/genproto v0.0.0-20200526211855-cb27e3aa2013/go.mod h1:NbSheEEYHJ7i3ixzK3sjbqSGDJWnxyFXZblF3eUsNvo=
 google.golang.org/genproto v0.0.0-20200618031413-b414f8b61790/go.mod h1:jDfRM7FcilCzHH/e9qn6dsT145K34l5v+OpcnNgKAAA=
 google.golang.org/genproto v0.0.0-20200729003335-053ba62fc06f/go.mod h1:FWY/as6DDZQgahTzZj3fqbO1CbirC29ZNUFHwi0/+no=
 google.golang.org/genproto v0.0.0-20200804131852-c06518451d9c/go.mod h1:FWY/as6DDZQgahTzZj3fqbO1CbirC29ZNUFHwi0/+no=
+google.golang.org/genproto v0.0.0-20200825200019-8632dd797987 h1:PDIOdWxZ8eRizhKa1AAvY53xsvLB1cWorMjslvY3VA8=
 google.golang.org/genproto v0.0.0-20200825200019-8632dd797987/go.mod h1:FWY/as6DDZQgahTzZj3fqbO1CbirC29ZNUFHwi0/+no=
 google.golang.org/grpc v1.19.0/go.mod h1:mqu4LbDTu4XGKhr4mRzUsmM4RtVoemTSY81AxZiDr8c=
 google.golang.org/grpc v1.20.1/go.mod h1:10oTOabMzJvdu6/UiuZezV6QK5dSlG84ov/aaiqXj38=
@@ -761,6 +769,8 @@ google.golang.org/grpc v1.28.0/go.mod h1:rpkK4SK4GF4Ach/+MFLZUBavHOvF2JJB5uozKKa
 google.golang.org/grpc v1.29.1/go.mod h1:itym6AZVZYACWQqET3MqgPpjcuV5QH3BxFS3IjizoKk=
 google.golang.org/grpc v1.30.0/go.mod h1:N36X2cJ7JwdamYAgDz+s+rVMFjt3numwzf/HckM8pak=
 google.golang.org/grpc v1.31.0/go.mod h1:N36X2cJ7JwdamYAgDz+s+rVMFjt3numwzf/HckM8pak=
+google.golang.org/grpc v1.33.1 h1:DGeFlSan2f+WEtCERJ4J9GJWk15TxUi8QGagfI87Xyc=
+google.golang.org/grpc v1.33.1/go.mod h1:fr5YgcSWrqhRRxogOsw7RzIpsmvOZ6IcH4kBYTpR3n0=
 google.golang.org/protobuf v0.0.0-20200109180630-ec00e32a8dfd/go.mod h1:DFci5gLYBciE7Vtevhsrf46CRTquxDuWsQurQQe4oz8=
 google.golang.org/protobuf v0.0.0-20200221191635-4d8936d0db64/go.mod h1:kwYJMbMJ01Woi6D6+Kah6886xMZcty6N08ah7+eCXa0=
 google.golang.org/protobuf v0.0.0-20200228230310-ab0ca4ff8a60/go.mod h1:cfTl7dwQJ+fmap5saPgwCLgHXTUD7jkjRqWcaiX5VyM=


### PR DESCRIPTION
Add support for Prometheus Remote Rewrote Protobuf-based Protocol. Note we are also using Snappy compression/decompression. This is only implemented on the Push (receiver) handler