### PR TITLE
GROUNDWORK-1674-add-perl:  add Perl and xorp.pl to the tcg container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,6 +24,9 @@ RUN sh -x \
         && cp *connector *config.yaml "$dest" \
         && cd -; \
     done \
+    && mkdir -p /tcg/snmp-connector/utils
+    && cp connectors/snmp-connector/utils/xorp.pl /tcg/snmp-connector/utils
+    && apk update && apk add perl
     && echo "[CONNECTORS DONE]"
 RUN cp ./docker_cmd.sh /app/
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,9 +24,9 @@ RUN sh -x \
         && cp *connector *config.yaml "$dest" \
         && cd -; \
     done \
-    && mkdir -p /tcg/snmp-connector/utils
-    && cp connectors/snmp-connector/utils/xorp.pl /tcg/snmp-connector/utils
-    && apk update && apk add perl
+    && mkdir -p /tcg/snmp-connector/utils \
+    && cp connectors/snmp-connector/utils/xorp.pl /tcg/snmp-connector/utils \
+    && apk update && apk add perl \
     && echo "[CONNECTORS DONE]"
 RUN cp ./docker_cmd.sh /app/
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,7 +26,7 @@ RUN sh -x \
     done \
     && mkdir -p /tcg/snmp-connector/utils \
     && cp connectors/snmp-connector/utils/xorp.pl /tcg/snmp-connector/utils \
-    && apk update && apk add perl \
+    && apt-get update && apt-get install perl \
     && echo "[CONNECTORS DONE]"
 RUN cp ./docker_cmd.sh /app/
 


### PR DESCRIPTION
We have found that our SNMPv3 code currently calls a small Perl helper
script to do its work.  In the interest of getting this working quickly
for a POC, I have modified the Dockerfile in a manner which I believe
will do the right things (adding Perl to the container, and installing
the Perl help script where it seems to be needed in actual usage).

Once we have validated that these changes have resolved the immediate
need, we can revisit these changes to see if a different permanent
solution is required.