### PR TITLE
GROUNDWORK-1662 Allow signals in docker containers

### DIFF
--- a/docker_cmd.sh
+++ b/docker_cmd.sh
@@ -15,4 +15,7 @@ if ! [ -f "${fs_var}/${connector}/tcg_config.yaml" ]; then
 fi
 
 cd "${fs_var}/${connector}" || exit 1
-"${fs_app}/${connector}/${connector}"
+
+# NOTE: do exec to replace shell process
+# so application will receive OS signals
+exec "${fs_app}/${connector}/${connector}"


### PR DESCRIPTION
How to test:
start tcg-apm container with debug loglevel, log tcg-apm container, and stop tcg-apm container from another terminal.

Before this PR:
got timeout and then message "dockergw8_tcg-apm_1 exited with code 137"

After this PR:
no timeout and got messages:
```
tcg-apm_1        | 2021-09-28T16:09:14Z INF ../../go/src/services/agentService.go:757 > signal terminated received, exiting
tcg-apm_1        | 2021-09-28T16:09:14Z DBG ../../go/src/services/agentService.go:347 > taskQueue Idx=4 Subject=exit
tcg-apm_1        | 2021-09-28T16:09:14Z INF ../../go/src/services/controller.go:153 > controller shutdown ...
dockergw8_tcg-apm_1 exited with code 0
```
