### PR TITLE
GROUNDWORK-1781 Encode metrics payload with gzip

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -111,6 +111,9 @@ type Connector struct {
 	Enabled            bool   `yaml:"enabled"`
 	InstallationMode   string `yaml:"installationMode,omitempty"`
 	IsDynamicInventory bool   `yaml:"-"`
+	// GWEncode defines using HTTPEncode in Groundwork client: child|force|off
+	// enabled for child by default
+	GWEncode string `yaml:"-"`
 
 	// LogCondense accepts time duration for condensing similar records
 	// if 0 turn off condensing
@@ -524,9 +527,12 @@ func (cfg *Config) LoadConnectorDTO(data []byte) (*ConnectorDTO, error) {
 	if cfg.IsConfiguringPMC() {
 		newCfg.Connector.InstallationMode = InstallationModePMC
 	}
-	/* apply dynamic inventory flag to gwConnections */
+	/* prepare gwConnections */
+	gwEncode := strings.ToLower(newCfg.Connector.GWEncode)
 	for i := range newCfg.GWConnections {
 		newCfg.GWConnections[i].IsDynamicInventory = newCfg.Connector.IsDynamicInventory
+		newCfg.GWConnections[i].HTTPEncode = gwEncode == "force" ||
+			(gwEncode != "off" && newCfg.GWConnections[i].IsChild)
 	}
 	/* update config */
 	*cfg.Connector = *newCfg.Connector

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/gwos/tcg
 
 go 1.17
 
-require github.com/gwos/tcg/sdk v0.0.0-20211223101342-35fbd1ae683c
+require github.com/gwos/tcg/sdk v0.0.0-20220104153456-e0ebadcc317d
 
 require (
 	github.com/PaesslerAG/gval v1.1.2

--- a/go.sum
+++ b/go.sum
@@ -267,8 +267,8 @@ github.com/gosnmp/gosnmp v1.34.0/go.mod h1:QWTRprXN9haHFof3P96XTDYc46boCGAh5IXp0
 github.com/gregjones/httpcache v0.0.0-20180305231024-9cad4c3443a7/go.mod h1:FecbI9+v66THATjSRHfNgh1IVFe/9kFxbXtjV0ctIMA=
 github.com/grpc-ecosystem/grpc-gateway v1.16.0 h1:gmcG1KaJ57LophUzW0Hy8NmPhnMZb4M0+kPpLofRdBo=
 github.com/grpc-ecosystem/grpc-gateway v1.16.0/go.mod h1:BDjrQk3hbvj6Nolgz8mAMFbcEtjT1g+wF4CSlocrBnw=
-github.com/gwos/tcg/sdk v0.0.0-20211223101342-35fbd1ae683c h1:befb5xGUwNCoBuN/akLFCKekUzr0ixyws3aAX/7TaOk=
-github.com/gwos/tcg/sdk v0.0.0-20211223101342-35fbd1ae683c/go.mod h1:OjlJNRXwlEjznVfU3YtLWH8FyM7KWHUevXDI47UeZeM=
+github.com/gwos/tcg/sdk v0.0.0-20220104153456-e0ebadcc317d h1:fqSlBCqn3kEGnUVStt+NaB6L+NP6u53pVjmp/Yaap1A=
+github.com/gwos/tcg/sdk v0.0.0-20220104153456-e0ebadcc317d/go.mod h1:OjlJNRXwlEjznVfU3YtLWH8FyM7KWHUevXDI47UeZeM=
 github.com/hashicorp/go-cleanhttp v0.5.0/go.mod h1:JpRdi6/HCYpAwUzNwuwqhbovhLtngrth3wmdIIUrZ80=
 github.com/hashicorp/go-hclog v0.9.1/go.mod h1:5CU+agLiy3J7N7QjHK5d05KxGsuXiQLrjA0H7acj2lQ=
 github.com/hashicorp/go-hclog v1.0.0 h1:bkKf0BeBXcSYa7f5Fyi9gMuQ8gNsxeiNpZjR6VxNZeo=

--- a/integration/nats_test.go
+++ b/integration/nats_test.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"os/exec"
 	"reflect"
+	"strings"
 	"testing"
 	"time"
 
@@ -195,6 +196,9 @@ func setupIntegration(t *testing.T, natsAckWait time.Duration) {
 			HostName:        GWValidHost,
 			UserName:        testGroundworkUserName,
 			Password:        testGroundworkPassword,
+
+			IsDynamicInventory: cfg.Connector.IsDynamicInventory,
+			HTTPEncode:         func() bool { return strings.ToLower(cfg.Connector.GWEncode) == "force" }(),
 		},
 	}
 

--- a/services/agentService.go
+++ b/services/agentService.go
@@ -767,4 +767,5 @@ func (service *AgentService) initOTEL() {
 		propagation.TraceContext{}, propagation.Baggage{}))
 
 	clients.HookRequestContext = tracing.HookRequestContext
+	clients.GZIP = tracing.GZIP
 }


### PR DESCRIPTION
Set it up with env vars:
TCG_CONNECTOR_GWENCODE=force

// GWEncode defines using HTTPEncode in Groundwork client: child|force|off
// enabled for child by default