### PR TITLE
GROUNDWORK-1936: Disable the metrics filtering feature 

### DIFF
--- a/connectors/apm-connector/apmConnector.go
+++ b/connectors/apm-connector/apmConnector.go
@@ -446,7 +446,7 @@ func pull(resources []Resource) {
 		}
 		logper.Info(req, "pull data from resource")
 		fmt.Println(string(req.Response))
-		err = processMetrics(req.Response, index, req.Status == 220, false, true)
+		err = processMetrics(req.Response, index, req.Status == 220, false, false)
 		if err != nil {
 			log.Err(err).Msg("could not process metrics")
 		}


### PR DESCRIPTION
Temporarily disable the metrics filtering feature until the UI is ready

!!! DO NOT MERGE !!!