### PR TITLE
GROUNDWORK-2596 Support self-signed certs in K8s connector

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,6 +222,8 @@ The [gotests](https://github.com/cweill/gotests) tool can generate Go tests.
         TCG_GWCONNECTIONS_0_USERNAME=remote TCG_GWCONNECTIONS_0_PASSWORD=remote \
         TCG_JAEGERTRACING_AGENT=localhost:6831 \
         TCG_CONNECTOR_LOGLEVEL=3 \
+        TCG_CONNECTOR_AGENTID=TEST11 \
+        TCG_TLS_CLIENT_INSECURE=TRUE \
         go test -v ./integration/
 
 

--- a/config/env.go
+++ b/config/env.go
@@ -78,10 +78,10 @@ func applyEnv(yamldoc []byte) []byte {
 		var key, val = pair[0], pair[1]
 		n := scalars[key]
 		if n == nil {
-			log.Warn().
-				// Interface("scalars", scalars). // TODO: remove
-				Str("env", env).
-				Msg("could not apply env: not found node")
+			// log.Debug().
+			// 	Interface("scalars", scalars). // TODO: remove
+			// 	Str("env", env).
+			// 	Msg("could not apply env: not found node")
 			continue
 		}
 		if n.ShortTag() == "!!null" {

--- a/connectors/office-connector/graphClient.go
+++ b/connectors/office-connector/graphClient.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"bytes"
-	"crypto/tls"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -13,6 +12,7 @@ import (
 
 	"github.com/PaesslerAG/jsonpath"
 	"github.com/gwos/tcg/connectors"
+	"github.com/gwos/tcg/sdk/clients"
 	"github.com/gwos/tcg/sdk/transit"
 	"github.com/rs/zerolog/log"
 )
@@ -21,11 +21,7 @@ const (
 	maxRetries = 5
 )
 
-var httpClient = &http.Client{
-	Transport: &http.Transport{
-		TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
-	},
-}
+var httpClient = clients.HttpClient
 
 func login(tenantID, clientID, clientSecret, resource string) (str string, err error) {
 	var (

--- a/integration/nats_test.go
+++ b/integration/nats_test.go
@@ -47,8 +47,8 @@ func TestNatsQueue1(t *testing.T) {
 	setupIntegration(t, 5*time.Second)
 
 	t.Log("Timeout all requests, messages will be stored in the queue")
-	defaultNetClientTimeout := *clients.NetClientTimeout
-	*clients.NetClientTimeout = 1 * time.Nanosecond
+	httpClientTimeout0 := clients.HttpClient.Timeout
+	clients.HttpClient.Timeout = 1 * time.Nanosecond
 
 	assert.NoError(t, services.GetTransitService().StopTransport())
 	m0 := services.GetTransitService().Stats().MessagesSent.Value()
@@ -68,7 +68,7 @@ func TestNatsQueue1(t *testing.T) {
 		return
 	}
 
-	*clients.NetClientTimeout = defaultNetClientTimeout
+	clients.HttpClient.Timeout = httpClientTimeout0
 	t.Log("Allow all requests")
 	assert.NoError(t, services.GetTransitService().StopTransport())
 	assert.NoError(t, services.GetTransitService().StartTransport())
@@ -89,8 +89,8 @@ func TestNatsQueue2(t *testing.T) {
 	setupIntegration(t, 30*time.Second)
 
 	t.Log("Timeout all requests, messages will be stored in the queue")
-	defaultNetClientTimeout := *clients.NetClientTimeout
-	*clients.NetClientTimeout = 1 * time.Nanosecond
+	httpClientTimeout0 := clients.HttpClient.Timeout
+	clients.HttpClient.Timeout = 1 * time.Nanosecond
 
 	assert.NoError(t, services.GetTransitService().StopTransport())
 	m0 := services.GetTransitService().Stats().MessagesSent.Value()
@@ -114,7 +114,7 @@ func TestNatsQueue2(t *testing.T) {
 	assert.NoError(t, services.GetTransitService().StopNats())
 	t.Log("NATS Server was stopped successfully")
 
-	*clients.NetClientTimeout = defaultNetClientTimeout
+	clients.HttpClient.Timeout = httpClientTimeout0
 	t.Log("Allow all requests")
 
 	t.Log("Starting NATS server ...")


### PR DESCRIPTION
It fixes and improves TLS processing CA certs.
There are few options how to set CA cert.

- Inject custom CA certificate into GW containers:
```
docker run -d --rm --name gw8-upload -v dockergw8_ulg:/usr/local/groundwork/config alpine:3.11 sleep 600
docker cp ./ca.pem gw8-upload:/usr/local/groundwork/config/cacerts/
docker stop gw8-upload
```
TCG service in docker-compose yaml should use `ulg` volume:
```
  tcg-k8s:
    image: groundworkdevelopment/tcg:${TAG}
    entrypoint: ["/app/docker_cmd.sh", "kubernetes-connector"]
    volumes:
      - tcg-var:/tcg
      - ulg:/usr/local/groundwork/config/
    extra_hosts:
      - "host.docker.internal:host-gateway"
```

- For K8s connector, cluster CA cert can be set with config yaml option in DalekUI.
Prepare config file with command:
```  
kubectl config view --flatten
```
Then load it in DalekUI connectors configuration form in `Kubernetes config file`.
Connector will use first cluster item and first user item.
So, fields `server`, `certificate-authority-data` in cluster
and fields `client-certificate-data`, `client-key-data`, or `token` in user.

K8s connector has additional configuration option `Insecure` for testing.
Server should be accessed without verifying the TLS certificate.

Also, we provide TCG_TLS_CLIENT_INSECURE env var.
It accepts 1, t, T, TRUE, true, True. Any other value means False/Off.
