### PR TITLE
GROUNDWORK-2651 elk: filter hosts with lucene

### DIFF
--- a/connectors/elastic-connector/clients/apiObjects.go
+++ b/connectors/elastic-connector/clients/apiObjects.go
@@ -100,7 +100,8 @@ type EsSearchBody struct {
 }
 
 type EsQuery struct {
-	Bool EsQueryBool `json:"bool"`
+	Bool *EsQueryBool `json:"bool,omitempty"`
+	Str  *EsQueryStr  `json:"query_string,omitempty"`
 }
 
 type EsQueryBool struct {
@@ -110,11 +111,9 @@ type EsQueryBool struct {
 	MustNot []interface{} `json:"must_not"`
 }
 
-type EsQueryString struct {
-	QueryString struct {
-		Query           string `json:"query"`
-		AnalyzeWildcard bool   `json:"analyze_wildcard"`
-	} `json:"query_string"`
+type EsQueryStr struct {
+	Query           string `json:"query"`
+	AnalyzeWildcard bool   `json:"analyze_wildcard"`
 }
 
 type EsAggs struct {

--- a/connectors/elastic-connector/clients/queryTranslator.go
+++ b/connectors/elastic-connector/clients/queryTranslator.go
@@ -9,9 +9,16 @@ import (
 
 // = buildEsQuery method in /kibana/src/plugins/data/common/es_query/es_query/build_es_query.ts
 func BuildEsQuery(storedQuery KSavedObject) EsQuery {
-	var esQuery EsQuery
+	esQuery := EsQuery{Bool: &EsQueryBool{}}
 	if storedQuery.Attributes == nil {
 		return esQuery
+	}
+
+	if FilterHostsWithLucene != "" {
+		esQuery.Bool.Must = append(esQuery.Bool.Must, EsQuery{Str: &EsQueryStr{
+			Query:           FilterHostsWithLucene,
+			AnalyzeWildcard: true,
+		}})
 	}
 
 	if storedQuery.Attributes.Query != nil &&
@@ -33,9 +40,10 @@ func BuildEsQuery(storedQuery KSavedObject) EsQuery {
 			}
 		case "lucene":
 			/* similar to Kibana, create query_string and use as 1st must member */
-			qs := EsQueryString{}
-			qs.QueryString.AnalyzeWildcard = true
-			qs.QueryString.Query = storedQuery.Attributes.Query.Query
+			qs := EsQuery{Str: &EsQueryStr{
+				Query:           storedQuery.Attributes.Query.Query,
+				AnalyzeWildcard: true,
+			}}
 			esQuery.Bool.Must = append(esQuery.Bool.Must, qs)
 		}
 	}

--- a/connectors/elastic-connector/elasticConnector.go
+++ b/connectors/elastic-connector/elasticConnector.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
-	"os"
 	"sort"
 	"strings"
 	"time"
@@ -20,10 +19,6 @@ import (
 	"github.com/rs/zerolog/log"
 	"go.opentelemetry.io/otel/attribute"
 )
-
-// EnvELKFilterHostsWithLucene provides pre-filter to reduce inventory size
-// TCG_ELK_FILTER_HOSTS_WITH_LUCENE='container.name:*a1test*'
-const EnvELKFilterHostsWithLucene = "TCG_ELK_FILTER_HOSTS_WITH_LUCENE"
 
 // ElasticView describes flow
 type ElasticView string
@@ -149,9 +144,6 @@ type ElasticConnector struct {
 // LoadConfig updates state
 func (connector *ElasticConnector) LoadConfig(config ExtConfig) error {
 	clients.FilterHostsWithLucene = config.FilterHostsWithLucene
-	if s, ok := os.LookupEnv(EnvELKFilterHostsWithLucene); ok {
-		clients.FilterHostsWithLucene = s
-	}
 
 	kibanaClient, esClient, err := initClients(config)
 	if err != nil {

--- a/connectors/elastic-connector/elasticConnector.go
+++ b/connectors/elastic-connector/elasticConnector.go
@@ -149,7 +149,8 @@ func (connector *ElasticConnector) LoadConfig(config ExtConfig) error {
 	if err != nil {
 		return err
 	}
-	monitoringState := config.initMonitoringState(connector.monitoringState, &esClient)
+	// drop previousState
+	monitoringState := config.initMonitoringState(MonitoringState{}, &esClient)
 
 	connector.config = config
 	connector.kibanaClient = kibanaClient

--- a/connectors/elastic-connector/elasticConnector_test.go
+++ b/connectors/elastic-connector/elasticConnector_test.go
@@ -137,7 +137,7 @@ func TestInitFullConfig(t *testing.T) {
 	  }
 	}`)
 
-	cfgChksum, _ = connectors.Hashsum(expected)
+	_, _ = connectors.Hashsum(expected)
 	_, _ = config.GetConfig().LoadConnectorDTO(data)
 	configHandler(data)
 
@@ -175,7 +175,7 @@ func TestInitConfigWithNotPresentedValues(t *testing.T) {
 
 	data := []byte(`{}`)
 
-	cfgChksum, _ = connectors.Hashsum(expected)
+	_, _ = connectors.Hashsum(expected)
 	_, _ = config.GetConfig().LoadConnectorDTO(data)
 	configHandler(data)
 
@@ -219,7 +219,7 @@ func TestInitConfigWithPartialPresentedValues(t *testing.T) {
 		}
 	}`)
 
-	cfgChksum, _ = connectors.Hashsum(expected)
+	_, _ = connectors.Hashsum(expected)
 	_, _ = config.GetConfig().LoadConnectorDTO(data)
 	configHandler(data)
 
@@ -263,7 +263,7 @@ func TestHandleEmptyConfig(t *testing.T) {
 		}
 	}`)
 
-	cfgChksum, _ = connectors.Hashsum(expected)
+	_, _ = connectors.Hashsum(expected)
 	_, _ = config.GetConfig().LoadConnectorDTO(data)
 	configHandler(data)
 


### PR DESCRIPTION
Reduce inventory size by applying additional filter in Lucene query syntax
https://www.elastic.co/guide/en/kibana/7.17/lucene-query.html.

Configured with new UI control, example: `container.name:*dalek* OR container.name:*tcg*`