### PR TITLE
GROUNDWORK-4324 clarify debug details in logging

### DIFF
--- a/batcher/events/events.go
+++ b/batcher/events/events.go
@@ -2,6 +2,7 @@ package events
 
 import (
 	"encoding/json"
+	"fmt"
 
 	"github.com/gwos/tcg/sdk/transit"
 	"github.com/rs/zerolog/log"
@@ -55,7 +56,7 @@ func (bld *EventsBatchBuilder) Build(buf *[][]byte, maxBytes int) {
 			continue
 		}
 		log.Err(err).
-			Any("events", q).
+			Str("events", fmt.Sprintf("%+v", q)).
 			Msg("could not marshal events")
 	}
 }

--- a/batcher/metrics/metrics.go
+++ b/batcher/metrics/metrics.go
@@ -70,7 +70,7 @@ func (bld *MetricsBatchBuilder) Build(buf *[][]byte, maxBytes int) {
 			continue
 		}
 		log.Err(err).
-			Any("resources", q).
+			Str("resources", fmt.Sprintf("%+v", q)).
 			Msg("could not marshal resources")
 	}
 }

--- a/config/config.go
+++ b/config/config.go
@@ -59,10 +59,11 @@ const (
 	Warn
 	Info
 	Debug
+	Trace
 )
 
 func (l LogLevel) String() string {
-	return [...]string{"Error", "Warn", "Info", "Debug"}[l]
+	return [...]string{"Error", "Warn", "Info", "Debug", "Trace"}[l]
 }
 
 type Nats struct {
@@ -524,7 +525,10 @@ func (cfg Config) Hashsum() ([]byte, error) {
 }
 
 func (cfg Config) initLogger() {
-	lvl := [...]zerolog.Level{3, 2, 1, 0}[cfg.Connector.LogLevel]
+	if cfg.Connector.LogLevel > 4 {
+		cfg.Connector.LogLevel = 4
+	}
+	lvl := [...]zerolog.Level{3, 2, 1, 0, -1}[cfg.Connector.LogLevel]
 	opts := []logzer.Option{
 		logzer.WithLastErrors(10),
 		logzer.WithLevel(lvl),

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"expvar"
 	"fmt"
 	"runtime"
 	"testing"
@@ -158,7 +159,7 @@ func BenchmarkE2E(b *testing.B) {
 		time.Sleep(5 * time.Second) // time for batcher + dispatcher
 		runtime.GC()
 		printMemStats()
-		printTcgStats()
+		printExpvar()
 
 		if transitService.BatchMaxBytes == 0 {
 			if cnt, dc := b.N*TestResourcesCount*TestResourcesCount, transitService.Stats().MessagesSent.Value()-m0; dc != int64(cnt) {
@@ -223,6 +224,9 @@ func memstats() any {
 func printMemStats() {
 	println("\n~", time.Now().Format(time.DateTime), "MEM_STATS", fmt.Sprintf("%+v", memstats()))
 }
-func printTcgStats() {
-	println("\n~", time.Now().Format(time.DateTime), "TCG_STATS", fmt.Sprintf("%+v", services.GetTransitService().Stats()))
+func printExpvar() {
+	// println("\n~", time.Now().Format(time.DateTime), "TCG_STATS", fmt.Sprintf("%+v", services.GetTransitService().Stats()))
+	buf := new(bytes.Buffer)
+	expvar.Do(func(kv expvar.KeyValue) { fmt.Fprintln(buf, kv.Key+": "+kv.Value.String()) })
+	println("\n~", time.Now().Format(time.DateTime), "TCG_EXPVAR", "\n", buf.String())
 }

--- a/logzer/logzer.go
+++ b/logzer/logzer.go
@@ -100,7 +100,7 @@ func (w *CondenseWriter) onEvicted() func(string, interface{}) {
 			case zerolog.TimeFormatUnix:
 				return strconv.AppendInt(dst, ts.Unix(), 10)
 			case zerolog.TimeFormatUnixMs:
-				return strconv.AppendInt(dst, ts.UnixNano()/1000000, 10)
+				return strconv.AppendInt(dst, ts.UnixMilli(), 10)
 			case zerolog.TimeFormatUnixMicro:
 				return strconv.AppendInt(dst, ts.UnixNano()/1000, 10)
 			}

--- a/nats/dispatcher.go
+++ b/nats/dispatcher.go
@@ -60,43 +60,44 @@ func (d *natsDispatcher) OpenDurable(ctx context.Context, opt DurableCfg) {
 		nats.DirectGet(),
 	)
 	if err != nil {
-		log.Warn().Err(err).
+		log.Err(err).
 			Str("durable", opt.Durable).
 			Msg("nats dispatcher failed JetStream")
 		return
 	}
 
-	if _, err := js.ConsumerInfo(streamName, opt.Durable); errors.Is(err, nats.ErrConsumerNotFound) {
-		if _, err = js.AddConsumer(streamName, &nats.ConsumerConfig{
-			// AckWait:       d.config.AckWait,
+	consumerName, durableName := opt.Durable, opt.Durable
+	if _, err := js.ConsumerInfo(streamName, consumerName); errors.Is(err, nats.ErrConsumerNotFound) {
+		if _, err := js.AddConsumer(streamName, &nats.ConsumerConfig{
+			AckWait:       d.config.AckWait,
 			AckPolicy:     nats.AckExplicitPolicy,
 			DeliverPolicy: nats.DeliverLastPolicy,
-			Durable:       opt.Durable,
-			Name:          opt.Durable,
+			Durable:       durableName,
+			Name:          consumerName,
 		}); err != nil {
-			log.Warn().Err(err).
+			log.Err(err).
 				Str("durable", opt.Durable).
 				Msg("nats dispatcher failed AddConsumer")
 			return
 		}
 	} else if err != nil {
-		log.Warn().Err(err).
+		log.Err(err).
 			Str("durable", opt.Durable).
 			Msg("nats dispatcher failed ConsumerInfo")
 		return
 	}
 
 	sub, err := js.PullSubscribe(
-		"", opt.Durable,
+		"", durableName,
 
-		nats.Bind(streamName, opt.Durable),
+		nats.Bind(streamName, consumerName),
 		// nats.BindStream(streamName),
 		// nats.Durable(opt.Durable),
-		// nats.AckWait(d.config.AckWait),
+		nats.AckWait(d.config.AckWait),
 		nats.ManualAck(),
 	)
 	if err != nil {
-		log.Warn().Err(err).
+		log.Err(err).
 			Str("durable", opt.Durable).
 			Msg("nats dispatcher failed Subscribe")
 		return
@@ -122,7 +123,7 @@ func (d *natsDispatcher) fetch(ctx context.Context, opt DurableCfg, sub *nats.Su
 		// using a batch size of more than 1 allows for higher throughput when needed.
 		msgs, err := sub.Fetch(4, nats.Context(ctx))
 		if err != nil && !errors.Is(err, context.Canceled) && !errors.Is(err, context.DeadlineExceeded) {
-			log.Warn().Err(err).
+			log.Err(err).
 				Str("durable", opt.Durable).
 				Msg("nats dispatcher failed Fetch")
 			continue

--- a/nats/dispatcher.go
+++ b/nats/dispatcher.go
@@ -185,7 +185,7 @@ func (d *natsDispatcher) fetch(ctx context.Context, opt DurableCfg, sub *nats.Su
 	}
 }
 
-func (d *natsDispatcher) processMsg(_ context.Context, opt DurableCfg, msg *nats.Msg) *dispatcherRetry {
+func (d *natsDispatcher) processMsg(ctx context.Context, opt DurableCfg, msg *nats.Msg) *dispatcherRetry {
 	meta, err := msg.Metadata()
 	if err != nil {
 		log.Warn().Err(err).Str("msg", fmt.Sprintf("%+v", *msg)).
@@ -215,7 +215,7 @@ func (d *natsDispatcher) processMsg(_ context.Context, opt DurableCfg, msg *nats
 		}
 	}
 
-	err = opt.Handler(NatsMsg{msg})
+	err = opt.Handler(ctx, NatsMsg{msg})
 	if err == nil {
 		d.duraSeqs.Set(opt.Durable, meta.Sequence.Stream, -1)
 		log.Info().Func(logDetailsFn()).

--- a/nats/nats.go
+++ b/nats/nats.go
@@ -113,7 +113,7 @@ func StartServer(config Config) error {
 		} else {
 			log.Warn().
 				Err(err).
-				Any("natsOpts", *opts).
+				Str("natsOpts", fmt.Sprintf("%+v", *opts)).
 				Msg("nats failed NewServer")
 			return err
 		}
@@ -126,7 +126,7 @@ func StartServer(config Config) error {
 	log.Info().
 		Func(func(e *zerolog.Event) {
 			if zerolog.GlobalLevel() <= zerolog.DebugLevel {
-				e.Any("natsOpts", *opts)
+				e.Str("natsOpts", fmt.Sprintf("%+v", *opts))
 			}
 		}).
 		Msgf("nats started at: %s", s.server.ClientURL())
@@ -216,22 +216,22 @@ func doStream(js nats.JetStreamContext, curCfg, newCfg *nats.StreamConfig) error
 		u, errUsage := disk.Usage(s.config.StoreDir)
 		if errUsage != nil {
 			log.Err(err).
-				Any("config", *newCfg).
-				Any("diskUsage", errUsage).
+				Str("config", fmt.Sprintf("%+v", *newCfg)).
+				Str("diskUsage", errUsage.Error()).
 				Msgf("nats failed %v, could not repair due to disk.Usage error", fnDesc)
 			return err
 		}
 		if u.Free/8*5 > uint64(newCfg.MaxBytes) {
 			log.Err(err).
-				Any("config", *newCfg).
-				Any("diskUsage", u).
+				Str("config", fmt.Sprintf("%+v", *newCfg)).
+				Str("diskUsage", fmt.Sprintf("%+v", *u)).
 				Msgf("nats failed %v, could not repair due to unexpected disk.Free", fnDesc)
 			return err
 		}
 		if u.Free < 1024*1024 {
 			log.Err(err).
-				Any("config", *newCfg).
-				Any("diskUsage", u).
+				Str("config", fmt.Sprintf("%+v", *newCfg)).
+				Str("diskUsage", fmt.Sprintf("%+v", *u)).
 				Msgf("nats failed %v, could not repair due to low disk.Free", fnDesc)
 			return err
 		}
@@ -241,16 +241,16 @@ func doStream(js nats.JetStreamContext, curCfg, newCfg *nats.StreamConfig) error
 		newCfg.MaxBytes = mb
 		_, err2 := fn(newCfg)
 		log.Err(err2).
-			Any("originalError", err).
-			Any("originalConfig", origCfg).
-			Any("reducedMaxBytes", mb).
-			Any("disk.Free", u.Free).
+			Str("originalError", err.Error()).
+			Str("originalConfig", fmt.Sprintf("%+v", origCfg)).
+			Int64("reducedMaxBytes", mb).
+			Uint64("disk.Free", u.Free).
 			Msgf("nats retrying %v with smaller storage", fnDesc)
 		return err2
 	}
 
 	log.Err(err).
-		Any("config", *newCfg).
+		Str("config", fmt.Sprintf("%+v", *newCfg)).
 		Msgf("nats %v", fnDesc)
 	return err
 }

--- a/nats/nats.go
+++ b/nats/nats.go
@@ -66,7 +66,7 @@ type Config struct {
 type DurableCfg struct {
 	Durable string
 	Subject string
-	Handler func(msg NatsMsg) error
+	Handler func(context.Context, NatsMsg) error
 }
 
 type NatsMsg struct {

--- a/nats/nats.go
+++ b/nats/nats.go
@@ -65,7 +65,6 @@ type Config struct {
 // DurableCfg defines subscription
 type DurableCfg struct {
 	Durable string
-	Subject string
 	Handler func(context.Context, NatsMsg) error
 }
 

--- a/sdk/clients/gwClient.go
+++ b/sdk/clients/gwClient.go
@@ -549,7 +549,8 @@ func (client *GWClient) sendRequest(ctx context.Context, httpMethod string, entr
 	switch {
 	case err != nil:
 		sdklog.Logger.LogAttrs(ctx, slog.LevelError, "could not send request", req.LogAttrs()...)
-		if tcgerr.IsErrorDNS(err) || tcgerr.IsErrorConnection(err) || tcgerr.IsErrorTimedOut(err) {
+		if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) ||
+			tcgerr.IsErrorDNS(err) || tcgerr.IsErrorConnection(err) || tcgerr.IsErrorTimedOut(err) {
 			return nil, fmt.Errorf("%w: %v", tcgerr.ErrTransient, err.Error())
 		}
 		return nil, err

--- a/services/agent.go
+++ b/services/agent.go
@@ -125,8 +125,8 @@ func GetAgentService() *AgentService {
 		}
 
 		log.Debug().
-			Any("connector", agentService.Connector).
-			Any("suppress", config.Suppress).
+			Str("connector", fmt.Sprintf("%+v", *agentService.Connector)).
+			Str("suppress", fmt.Sprintf("%+v", config.Suppress)).
 			Bool("tlsClientInsecure", clients.HttpClientTransport.TLSClientConfig.InsecureSkipVerify).
 			Str("httpClientTimeout", clients.HttpClient.Timeout.String()).
 			Str("httpClientTimeoutGW", clients.HttpClientGW.Timeout.String()).
@@ -327,7 +327,7 @@ func (service *AgentService) Status() AgentStatus {
 func (service *AgentService) handleTasks() {
 	hDebug := func(tt []taskqueue.Task) {
 		log.Error().
-			Any("lastTasks", tt).
+			Str("lastTasks", fmt.Sprintf("%+v", tt)).
 			Msg("task queue")
 	}
 	hAlarm := func(task *taskqueue.Task) error {

--- a/services/nats.go
+++ b/services/nats.go
@@ -63,18 +63,18 @@ func getCtx(ctx context.Context, sc trace.SpanContext) context.Context {
 	return ctx
 }
 
-func makeDurable(durable, subj string, handleWithCtx func(context.Context, []byte) error) nats.DurableCfg {
+func makeDurable(durable string, handleWithCtx func(context.Context, []byte) error) nats.DurableCfg {
 	for _, s := range []string{"/", ".", "*", ">"} {
 		durable = strings.ReplaceAll(durable, s, "")
 	}
 	return nats.DurableCfg{
 		Durable: durable,
-		Subject: subj,
 		Handler: func(ctx context.Context, msg nats.NatsMsg) error {
 			var (
 				err     error
 				data    = msg.Data
 				headers = msg.Header
+				subject = msg.Subject
 				sCtxCfg = trace.SpanContextConfig{}
 				spanID  []byte
 				traceID []byte
@@ -113,7 +113,7 @@ func makeDurable(durable, subj string, handleWithCtx func(context.Context, []byt
 					tracing.TraceAttrPayloadLen(data),
 					tracing.TraceAttrStr("type", headers.Get(clients.HdrPayloadType)),
 					tracing.TraceAttrStr("durable", durable),
-					tracing.TraceAttrStr("subject", subj),
+					tracing.TraceAttrStr("subject", subject),
 				)
 			}()
 
@@ -149,23 +149,10 @@ func makeSubscriptions(gwClients []clients.GWClient) []nats.DurableCfg {
 	for i := range gwClients {
 		// gwClient := gwClient /* hold loop var copy */
 		gwClient := &gwClients[i]
-		subs = append(subs,
-			makeDurable(
-				fmt.Sprintf("#%s#%s#", subjDowntimes, gwClient.HostName),
-				subjDowntimes,
-				adaptClient(gwClient),
-			),
-			makeDurable(
-				fmt.Sprintf("#%s#%s#", subjEvents, gwClient.HostName),
-				subjEvents,
-				adaptClient(gwClient),
-			),
-			makeDurable(
-				fmt.Sprintf("#%s#%s#", subjInventoryMetrics, gwClient.HostName),
-				subjInventoryMetrics,
-				adaptClient(gwClient),
-			),
-		)
+		subs = append(subs, makeDurable(
+			fmt.Sprintf("#%s#", gwClient.HostName),
+			adaptClient(gwClient),
+		))
 	}
 	return subs
 }

--- a/services/services.go
+++ b/services/services.go
@@ -182,7 +182,7 @@ type AgentStatus struct {
 }
 
 func (p AgentStatus) String() string {
-	return fmt.Sprintf("[Nats:%v Transport:%v Controller:%v]",
+	return fmt.Sprintf("{Nats:%v Transport:%v Controller:%v}",
 		p.Nats.Value(), p.Transport.Value(), p.Controller.Value())
 }
 


### PR DESCRIPTION
Somehow with zerolog .Any(k, v) method prints lesser fields then .Str(k, fmt.Sprintf("%+v", v))