### PR TITLE
GROUNDWORK-4324 support extended inventory

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,16 +41,19 @@ LIBTRANSITJSON_OBJECTS = \
 
 LIBTRANSIT_DIRECTORY = libtransit
 
-LIBTRANSIT_SOURCE = ${LIBTRANSIT_DIRECTORY}/libtransit.go
+# LIBTRANSIT_SOURCE = ${LIBTRANSIT_DIRECTORY}/*.go
 
-LIBTRANSIT_HEADER = ${LIBTRANSIT_DIRECTORY}/libtransit.h
+LIBTRANSIT_HEADERS = \
+	${LIBTRANSIT_DIRECTORY}/libtransit_compat.h \
+	${LIBTRANSIT_DIRECTORY}/libtransit.h \
+	${LIBTRANSIT_DIRECTORY}/transit.h
 
 LIBTRANSIT_LIBRARY = ${LIBTRANSIT_DIRECTORY}/libtransit.so
 
 LIBTRANSITJSON_LIBRARY = ${BUILD_TARGET_DIRECTORY}/libtransitjson.so
 
 BUILD_HEADER_FILES = \
-	${LIBTRANSIT_HEADER}				\
+	${LIBTRANSIT_DIRECTORY}/libtransit_compat.h	\
 	gotocjson/_c_code/convert_go_to_c.h		\
 	${BUILD_TARGET_DIRECTORY}/time.h		\
 	${BUILD_TARGET_DIRECTORY}/generic_datatypes.h	\
@@ -107,7 +110,7 @@ get	:
 	go get github.com/nats-io/go-nats-streaming
 	go get github.com/nats-io/nats-streaming-server/server
 
-# For the ${LIBTRANSIT_HEADER} and ${LIBTRANSIT_LIBRARY} targets, there are many more
+# For the ${LIBTRANSIT_HEADERS} and ${LIBTRANSIT_LIBRARY} targets, there are many more
 # dependencies than we ought to be keeping track of here, and they are all tracked
 # instead in the subsidiary Makefile where those targets are actually built.  So instead
 # of just depending on ${LIBTRANSIT_SOURCE}, which is of course the principal source file
@@ -117,7 +120,7 @@ get	:
 
 .PHONY	: ${LIBTRANSIT_DIRECTORY}
 
-${LIBTRANSIT_HEADER} ${LIBTRANSIT_LIBRARY}	: ${LIBTRANSIT_DIRECTORY}
+${LIBTRANSIT_HEADERS} ${LIBTRANSIT_LIBRARY}	: ${LIBTRANSIT_DIRECTORY}
 	make -C ${LIBTRANSIT_DIRECTORY}
 
 ${BUILD_TARGET_DIRECTORY}	:
@@ -163,6 +166,9 @@ ${LIBTRANSITJSON_LIBRARY}	: ${LIBTRANSITJSON_OBJECTS}
 
 clean	:
 	rm -rf ${BUILD_TARGET_DIRECTORY}
+	rm -f ${INSTALL_HEADER_FILES} ${INSTALL_DYNAMIC_LIBRARIES}
+	rm -rf ${INSTALL_DIRECTORIES} ${INSTALL_BASE_DIRECTORY}
+	make -C libtransit clean
 	make -C gotocjson clean
 
 .PHONY	: realclean

--- a/README.md
+++ b/README.md
@@ -89,15 +89,15 @@ The TCG project is built with Go Modules. See `go.mod` for a list of dependencie
         github.com/shirou/gopsutil
 
 9. [Gin-Swagger](github.com/swaggo/gin-swagger)
-    
+
     > Gin Gonic middleware to automatically generate RESTful API documentation with Swagger 2.0.
-                                                        
+
         github.com/swaggo/gin-swagger
-        
+
     > Generate 'docs.go' for Swagger UI
-        
+
         $ swag init
-    
+
     > Swagger url:
 
         {host}:{port}/swagger/index.html
@@ -144,28 +144,28 @@ go tool dist list -json
 go tool dist list -json | jq '.[] | select(.CgoSupported == true)'
 ```
 
-## Installing as a service 
-To enable:      
+## Installing as a service
+To enable:
 ```
 sudo systemctl enable tcg-elastic
 ```
-To start:       
+To start:
 ```
 sudo systemctl start tcg-elastic
 ```
-Show status:    
+Show status:
 ```
 sudo systemctl status tcg-elastic
 ```
-To stop:        
+To stop:
 ```
 sudo systemctl stop tcg-elastic
 ```
-To disable:     
+To disable:
 ```
 sudo systemctl disable tcg-elastic
 ```
-To reconfigure: 
+To reconfigure:
 ```
 sudo systemctl daemon-reload
 ```
@@ -201,7 +201,7 @@ The [gotests](https://github.com/cweill/gotests) tool can generate Go tests.
 >With logs:
 
     $ go test -v ./<package_one>/ ./<package_two>/
-    
+
 ### Run integration tests:
 
 >For integration tests you must provide environment variables for Groundwork Connection. Also have to deal with TLS certs: get it in local trust storage or suppress check.
@@ -270,6 +270,7 @@ There are additional variables supported:
     * OTEL_EXPORTER_OTLP_ENDPOINT=http://jaegertracing:4317
     * TCG_HTTP_CLIENT_TIMEOUT=10s
     * TCG_HTTP_CLIENT_TIMEOUT_GW=120s
+    * TCG_INVENTORY_NOEXT=true
     * TCG_SUPPRESS_DOWNTIMES=true
     * TCG_SUPPRESS_EVENTS=true
     * TCG_SUPPRESS_INVENTORY=true

--- a/batcher/batcher.go
+++ b/batcher/batcher.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/gwos/tcg/tracing"
+	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
 	"go.opentelemetry.io/otel/trace"
 )
@@ -146,8 +147,10 @@ func (bt *Batcher) Batch() {
 			}()
 
 			bt.builder.Build(&buf, bt.maxBytes)
-			log.Trace().Str("bt.tracerName", bt.tracerName).
-				RawJSON("buf", append(append([]byte("["), bytes.Join(buf, []byte(","))...), ']')).
+			log.Trace().Func(func(e *zerolog.Event) { // process only if loglevel enabled
+				e.RawJSON("buf", append(append([]byte("["), bytes.Join(buf, []byte(","))...), ']'))
+			}).
+				Str("bt.tracerName", bt.tracerName).
 				Int("bufferLen", len(buf)).
 				Int("bufferSize", bufSize).
 				Int("maxBytes", bt.maxBytes).

--- a/batcher/events/events_test.go
+++ b/batcher/events/events_test.go
@@ -29,10 +29,11 @@ func TestBuild(t *testing.T) {
 	printMemStats()
 
 	qq := make([]transit.GroundworkEventsRequest, 0)
+	var q transit.GroundworkEventsRequest
 	for _, p := range buf {
-		q := new(transit.GroundworkEventsRequest)
-		assert.NoError(t, json.Unmarshal(p, q))
-		qq = append(qq, *q)
+		q = transit.GroundworkEventsRequest{}
+		assert.NoError(t, json.Unmarshal(p, &q))
+		qq = append(qq, q)
 	}
 	assert.Equal(t, 3, len(qq))
 	assert.Equal(t, 3, len(qq[0].Events))
@@ -44,9 +45,9 @@ func TestBuild(t *testing.T) {
 
 // inspired by expvar.Handler() implementation
 func memstats() any {
-	stats := new(runtime.MemStats)
-	runtime.ReadMemStats(stats)
-	return *stats
+	var stats runtime.MemStats
+	runtime.ReadMemStats(&stats)
+	return stats
 }
 func printMemStats() {
 	println("\n~", time.Now().Format(time.DateTime), "MEM_STATS", fmt.Sprintf("%+v", memstats()))

--- a/batcher/metrics/metrics.go
+++ b/batcher/metrics/metrics.go
@@ -43,7 +43,7 @@ func (bld *MetricsBatchBuilder) Build(buf *[][]byte, maxBytes int) {
 			continue
 		}
 
-		bq.SetContext(*q.Context)
+		bq.SetContext(q.Context)
 		bq.Groups = append(bq.Groups, q.Groups...)
 		bq.Resources = append(bq.Resources, q.Resources...)
 		c += len(p)
@@ -113,7 +113,7 @@ func xxl2qq(qq *[]transit.ResourcesWithServicesRequest, p []byte, maxBytes int) 
 			}
 
 			x.Resources = append(x.Resources, pr)
-			x.SetContext(*q.Context)
+			x.SetContext(q.Context)
 			*qq = append(*qq, x)
 
 			c, x = 0, transit.ResourcesWithServicesRequest{Groups: q.Groups}
@@ -123,7 +123,7 @@ func xxl2qq(qq *[]transit.ResourcesWithServicesRequest, p []byte, maxBytes int) 
 	}
 
 	if len(x.Resources) > 0 {
-		x.SetContext(*q.Context)
+		x.SetContext(q.Context)
 		*qq = append(*qq, x)
 	}
 

--- a/batcher/metrics/metrics_test.go
+++ b/batcher/metrics/metrics_test.go
@@ -202,9 +202,9 @@ func BenchmarkUpdateToken(b *testing.B) {
 
 // inspired by expvar.Handler() implementation
 func memstats() any {
-	stats := new(runtime.MemStats)
-	runtime.ReadMemStats(stats)
-	return *stats
+	var stats runtime.MemStats
+	runtime.ReadMemStats(&stats)
+	return stats
 }
 func printMemStats() {
 	println("\n~", time.Now().Format(time.DateTime), "MEM_STATS", fmt.Sprintf("%+v", memstats()))

--- a/batcher/metrics/metrics_test.go
+++ b/batcher/metrics/metrics_test.go
@@ -54,8 +54,8 @@ func TestResourcesWithServicesRequest(t *testing.T) {
 		}
 	]
 	}`)
-	q := new(transit.ResourcesWithServicesRequest)
-	assert.NoError(t, json.Unmarshal(p, q))
+	var q transit.ResourcesWithServicesRequest
+	assert.NoError(t, json.Unmarshal(p, &q))
 	s := fmt.Sprintf("%#v", q)
 	assert.Contains(t, s, `Status:"SERVICE_OK", LastCheckTime:<nil>, NextCheckTime:<nil>`)
 	/* no wrong dates added on re-marshaling */
@@ -74,16 +74,40 @@ func TestBuild(t *testing.T) {
 		}
 		mbb.Build(&buf, 1024)
 		qq := make([]transit.ResourcesWithServicesRequest, 0)
+		var q transit.ResourcesWithServicesRequest
 		for _, p := range buf {
-			q := new(transit.ResourcesWithServicesRequest)
-			assert.NoError(t, json.Unmarshal(p, q))
-			qq = append(qq, *q)
+			q = transit.ResourcesWithServicesRequest{}
+			assert.NoError(t, json.Unmarshal(p, &q))
+			qq = append(qq, q)
 		}
 		assert.Equal(t, 4, len(qq))
 		assert.Contains(t, qq[0].Context.TraceToken, "b491b98e-0000")
 		assert.Contains(t, qq[1].Context.TraceToken, "b491b98e-0001")
 		assert.Equal(t, 2, len(qq[0].Resources[0].Services))
 		assert.Equal(t, 2, len(qq[3].Resources[0].Services))
+
+		// bb, err := json.MarshalIndent(qq, "", "  ")
+		// assert.NoError(t, err)
+		// t.Logf("%#v\n\n%s", qq, bb)
+	})
+
+	t.Run("split oversized without metrics", func(t *testing.T) {
+		buf := [][]byte{
+			[]byte(`{"context":{"agentId":"a3d1a71c-3123-4cf4-bc44-493abe8d693e","appType":"NAGIOS","timeStamp":"1747733605675","traceToken":"b491b98e-c0cf-40c8-9938-3e30cb6a444c","version":"1.0.0"},"resources":[{"description":"atest11","device":"127.1.1.11","lastCheckTime":"1747756069000","lastPluginOutput":"OK - 127.1.1.11 rta 0.032ms lost 0%","name":"atest11","nextCheckTime":"1747756129000","properties":{"Alias":{"stringValue":"atest11","valueType":"StringType"},"CheckType":{"stringValue":"ACTIVE","valueType":"StringType"},"CurrentAttempt":{"integerValue":1,"valueType":"IntegerType"},"CurrentNotificationNumber":{"integerValue":0,"valueType":"IntegerType"},"ExecutionTime":{"doubleValue":0.003,"valueType":"DoubleType"},"LastNotificationTime":{"timeValue":"0","valueType":"TimeType"},"LastStateChange":{"timeValue":"1747683022000","valueType":"TimeType"},"Latency":{"doubleValue":0,"valueType":"DoubleType"},"MaxAttempts":{"integerValue":3,"valueType":"IntegerType"},"PercentStateChange":{"doubleValue":0,"valueType":"DoubleType"},"PerformanceData":{"stringValue":"rta=0.032ms;3000.000;5000.000;0; pl=0%;80;100;0;100 rtmax=0.032ms;;;; rtmin=0.032ms;;;;","valueType":"StringType"},"StateType":{"stringValue":"HARD","valueType":"StringType"},"isAcknowledged":{"boolValue":false,"valueType":"BooleanType"},"isChecksEnabled":{"boolValue":true,"valueType":"BooleanType"},"isEventHandlersEnabled":{"boolValue":true,"valueType":"BooleanType"},"isFlapDetectionEnabled":{"boolValue":true,"valueType":"BooleanType"},"isNotificationsEnabled":{"boolValue":true,"valueType":"BooleanType"},"isPassiveChecksEnabled":{"boolValue":true,"valueType":"BooleanType"}},"services":[{"lastCheckTime":"1747756069000","lastPluginOutput":"OK - 127.1.1.11 rta 0.050ms lost 0%","name":"icmp_ping_alive","nextCheckTime":"1747756129000","properties":{"CheckType":{"stringValue":"ACTIVE","valueType":"StringType"},"CurrentAttempt":{"integerValue":1,"valueType":"IntegerType"},"CurrentNotificationNumber":{"integerValue":0,"valueType":"IntegerType"},"ExecutionTime":{"doubleValue":0.004,"valueType":"DoubleType"},"LastNotificationTime":{"timeValue":"0","valueType":"TimeType"},"Latency":{"doubleValue":0,"valueType":"DoubleType"},"MaxAttempts":{"integerValue":3,"valueType":"IntegerType"},"PercentStateChange":{"doubleValue":0,"valueType":"DoubleType"},"PerformanceData":{"stringValue":"rta=0.050ms;3000.000;5000.000;0; pl=0%;80;100;0;100 rtmax=0.050ms;;;; rtmin=0.050ms;;;;","valueType":"StringType"},"StateType":{"stringValue":"HARD","valueType":"StringType"},"isAcceptPassiveChecks":{"boolValue":true,"valueType":"BooleanType"},"isChecksEnabled":{"boolValue":true,"valueType":"BooleanType"},"isEventHandlersEnabled":{"boolValue":true,"valueType":"BooleanType"},"isFlapDetectionEnabled":{"boolValue":true,"valueType":"BooleanType"},"isNotificationsEnabled":{"boolValue":true,"valueType":"BooleanType"},"isProblemAcknowledged":{"boolValue":false,"valueType":"BooleanType"}},"status":"SERVICE_OK","type":"service"}],"status":"HOST_UP","type":"host"},{"description":"atest22","device":"127.1.1.22","lastCheckTime":"1747756029000","lastPluginOutput":"OK - 127.1.1.22 rta 0.044ms lost 0%","name":"atest22","nextCheckTime":"1747756091000","properties":{"Alias":{"stringValue":"atest22","valueType":"StringType"},"CheckType":{"stringValue":"ACTIVE","valueType":"StringType"},"CurrentAttempt":{"integerValue":1,"valueType":"IntegerType"},"CurrentNotificationNumber":{"integerValue":0,"valueType":"IntegerType"},"ExecutionTime":{"doubleValue":0.003,"valueType":"DoubleType"},"LastNotificationTime":{"timeValue":"0","valueType":"TimeType"},"LastStateChange":{"timeValue":"1747683049000","valueType":"TimeType"},"Latency":{"doubleValue":0,"valueType":"DoubleType"},"MaxAttempts":{"integerValue":3,"valueType":"IntegerType"},"PercentStateChange":{"doubleValue":0,"valueType":"DoubleType"},"PerformanceData":{"stringValue":"rta=0.044ms;3000.000;5000.000;0; pl=0%;80;100;0;100 rtmax=0.044ms;;;; rtmin=0.044ms;;;;","valueType":"StringType"},"StateType":{"stringValue":"HARD","valueType":"StringType"},"isAcknowledged":{"boolValue":false,"valueType":"BooleanType"},"isChecksEnabled":{"boolValue":true,"valueType":"BooleanType"},"isEventHandlersEnabled":{"boolValue":true,"valueType":"BooleanType"},"isFlapDetectionEnabled":{"boolValue":true,"valueType":"BooleanType"},"isNotificationsEnabled":{"boolValue":true,"valueType":"BooleanType"},"isPassiveChecksEnabled":{"boolValue":true,"valueType":"BooleanType"}},"services":[{"lastCheckTime":"1747756060000","lastPluginOutput":"OK - 127.1.1.22 rta 0.031ms lost 0%","name":"icmp_ping_alive","nextCheckTime":"1747756120000","properties":{"CheckType":{"stringValue":"ACTIVE","valueType":"StringType"},"CurrentAttempt":{"integerValue":1,"valueType":"IntegerType"},"CurrentNotificationNumber":{"integerValue":0,"valueType":"IntegerType"},"ExecutionTime":{"doubleValue":0.003,"valueType":"DoubleType"},"LastNotificationTime":{"timeValue":"0","valueType":"TimeType"},"Latency":{"doubleValue":0,"valueType":"DoubleType"},"MaxAttempts":{"integerValue":3,"valueType":"IntegerType"},"PercentStateChange":{"doubleValue":0,"valueType":"DoubleType"},"PerformanceData":{"stringValue":"rta=0.031ms;3000.000;5000.000;0; pl=0%;80;100;0;100 rtmax=0.031ms;;;; rtmin=0.031ms;;;;","valueType":"StringType"},"StateType":{"stringValue":"HARD","valueType":"StringType"},"isAcceptPassiveChecks":{"boolValue":true,"valueType":"BooleanType"},"isChecksEnabled":{"boolValue":true,"valueType":"BooleanType"},"isEventHandlersEnabled":{"boolValue":true,"valueType":"BooleanType"},"isFlapDetectionEnabled":{"boolValue":true,"valueType":"BooleanType"},"isNotificationsEnabled":{"boolValue":true,"valueType":"BooleanType"},"isProblemAcknowledged":{"boolValue":false,"valueType":"BooleanType"}},"status":"SERVICE_OK","type":"service"}],"status":"HOST_UP","type":"host"}]}`),
+		}
+		mbb.Build(&buf, 1024)
+		qq := make([]transit.ResourcesWithServicesRequest, 0)
+		var q transit.ResourcesWithServicesRequest
+		for _, p := range buf {
+			q = transit.ResourcesWithServicesRequest{}
+			assert.NoError(t, json.Unmarshal(p, &q))
+			qq = append(qq, q)
+		}
+		assert.Equal(t, 2, len(qq))
+		assert.Contains(t, qq[0].Context.TraceToken, "b491b98e-0000")
+		assert.Contains(t, qq[1].Context.TraceToken, "b491b98e-0001")
+		assert.Equal(t, 1, len(qq[0].Resources[0].Services))
+		assert.Equal(t, 1, len(qq[1].Resources[0].Services))
 
 		// bb, err := json.MarshalIndent(qq, "", "  ")
 		// assert.NoError(t, err)
@@ -103,11 +127,12 @@ func TestBuild(t *testing.T) {
 		printMemStats()
 
 		qq := make([]transit.ResourcesWithServicesRequest, 0)
+		var q transit.ResourcesWithServicesRequest
 		for _, p := range buf {
 			// t.Logf("\n\n%s\n", p)
-			q := new(transit.ResourcesWithServicesRequest)
-			assert.NoError(t, json.Unmarshal(p, q))
-			qq = append(qq, *q)
+			q = transit.ResourcesWithServicesRequest{}
+			assert.NoError(t, json.Unmarshal(p, &q))
+			qq = append(qq, q)
 		}
 		assert.Equal(t, 3, len(qq))
 		assert.Equal(t, 1, len(qq[0].Groups))
@@ -127,11 +152,12 @@ func TestBuild(t *testing.T) {
 		}
 		mbb.Build(&buf, 10240)
 		qq := make([]transit.ResourcesWithServicesRequest, 0)
+		var q transit.ResourcesWithServicesRequest
 		for _, p := range buf {
 			// t.Logf("\n\n%s\n", p)
-			q := new(transit.ResourcesWithServicesRequest)
-			assert.NoError(t, json.Unmarshal(p, q))
-			qq = append(qq, *q)
+			q = transit.ResourcesWithServicesRequest{}
+			assert.NoError(t, json.Unmarshal(p, &q))
+			qq = append(qq, q)
 		}
 		assert.Equal(t, 4, len(qq))
 		assert.Equal(t, 0, len(qq[0].Groups))

--- a/connectors/elastic/clients/elasticSearchClient.go
+++ b/connectors/elastic/clients/elasticSearchClient.go
@@ -204,7 +204,7 @@ func parseSearchResponse(response *esapi.Response) *EsSearchResponse {
 	}
 
 	log.Debug().
-		Str("response", response.String()).
+		Stringer("response", response).
 		Msg("ES Search response")
 
 	if response.IsError() {
@@ -273,7 +273,7 @@ func (esClient EsClient) IsAggregatable(fieldNames []string, indexes []string) (
 	}
 
 	log.Debug().
-		Str("response", response.String()).
+		Stringer("response", response).
 		Msg("ES FieldCaps response")
 
 	if response.IsError() {

--- a/connectors/elastic/clients/elasticSearchClient.go
+++ b/connectors/elastic/clients/elasticSearchClient.go
@@ -171,8 +171,8 @@ func (esClient EsClient) doSearchRequest(searchBody EsSearchBody, indexes []stri
 		}
 	}
 	client := esClient.client
-	body := new(bytes.Buffer)
-	if err := json.NewEncoder(body).Encode(searchBody); err != nil {
+	var body bytes.Buffer
+	if err := json.NewEncoder(&body).Encode(searchBody); err != nil {
 		log.Err(err).Msg("could not encode ES Search Body")
 		return nil, err
 	}
@@ -184,7 +184,7 @@ func (esClient EsClient) doSearchRequest(searchBody EsSearchBody, indexes []stri
 	response, err := client.Search(
 		client.Search.WithContext(context.Background()),
 		client.Search.WithIndex(indexes...),
-		client.Search.WithBody(body),
+		client.Search.WithBody(&body),
 		client.Search.WithTrackTotalHits(true),
 		client.Search.WithSize(0),
 	)

--- a/connectors/elastic/clients/kibanaClient.go
+++ b/connectors/elastic/clients/kibanaClient.go
@@ -118,10 +118,10 @@ func (client *KibanaClient) GetDefaultIndexID() string {
 			Msgf("Kibana Get Default Index request: %s", path)
 	}
 
-	p := new(struct {
+	var p struct {
 		IndexPatternID string `json:"index_pattern_id"`
-	})
-	if err := json.Unmarshal(response, p); err != nil {
+	}
+	if err := json.Unmarshal(response, &p); err != nil {
 		log.Err(err).Msg("could not parse Kibana Get Default Index response")
 		return ""
 	}
@@ -215,8 +215,8 @@ func (client *KibanaClient) BulkGetSO(savedObjectType KibanaSavedObjectType, ids
 			Msgf("Kibana Bulk Get Saved Objects request: %s", path)
 	}
 
-	bulkResponse := new(KBulkGetSOResponse)
-	if err := json.Unmarshal(response, bulkResponse); err != nil {
+	var bulkResponse KBulkGetSOResponse
+	if err := json.Unmarshal(response, &bulkResponse); err != nil {
 		log.Err(err).Msg("could not parse Kibana Bulk Get Saved Objects response")
 		return nil
 	}
@@ -279,8 +279,8 @@ func (client *KibanaClient) BulkResolveSO(savedObjectType KibanaSavedObjectType,
 			Msgf("Kibana Bulk Resolve Saved Objects request: %s", path)
 	}
 
-	bulkResponse := new(KBulkResolveSOResponse)
-	if err := json.Unmarshal(response, bulkResponse); err != nil {
+	var bulkResponse KBulkResolveSOResponse
+	if err := json.Unmarshal(response, &bulkResponse); err != nil {
 		log.Err(err).Msg("could not parse Kibana Bulk Resolve Saved Objects response")
 		return nil
 	}

--- a/connectors/elastic/clients/kibana_test.go
+++ b/connectors/elastic/clients/kibana_test.go
@@ -29,8 +29,8 @@ func TestBulkGetSavedObjects(t *testing.T) {
     }
   }
 ]}`)
-	bulkResponse := new(KBulkGetSOResponse)
-	assert.NoError(t, json.Unmarshal(res, bulkResponse))
+	var bulkResponse KBulkGetSOResponse
+	assert.NoError(t, json.Unmarshal(res, &bulkResponse))
 
 	actualErrors, expectedErrors := 0, 1
 	savedObjects := make([]KSavedObject, 0)

--- a/connectors/office/graphClient.go
+++ b/connectors/office/graphClient.go
@@ -120,7 +120,7 @@ func ExecuteRequest(graphURI, token string) ([]byte, error) {
 		}
 		if response.StatusCode != 200 {
 			b, _ := io.ReadAll(response.Body)
-			log.Debug().Msg(fmt.Sprintf("[url=%s][response=%s]", graphURI, string(b)))
+			log.Debug().Msgf("[url=%s][response=%s]", graphURI, string(b))
 			_ = response.Body.Close()
 			return nil, errors.New(fmt.Sprintf("error to get data. [url: %s, status code: %d", graphURI, response.StatusCode))
 		}

--- a/connectors/snmp/snmp_test.go
+++ b/connectors/snmp/snmp_test.go
@@ -2263,7 +2263,7 @@ func seedTest() (*MonitoringState, map[string]transit.MetricDefinition, []transi
 		return nil, nil, nil, err
 	}
 
-	state := new(MonitoringState)
+	var state MonitoringState
 	if err := json.Unmarshal(devicesJSON, &state.devices); err != nil {
 		return nil, nil, nil, err
 	}
@@ -2277,5 +2277,5 @@ func seedTest() (*MonitoringState, map[string]transit.MetricDefinition, []transi
 		return nil, nil, nil, err
 	}
 
-	return state, metricDefinitions, mResources, nil
+	return &state, metricDefinitions, mResources, nil
 }

--- a/deprecated/README.md
+++ b/deprecated/README.md
@@ -1,5 +1,7 @@
 
 ## deprecated packages
 
-There are packages required by integration with the `gotocjson` tool.
+There are packages required by integration with `DataGeyser`
+and processed by the `gotocjson` tool.
+
 All new development should use packages from `sdk` module instead.

--- a/deprecated/transit/transit.go
+++ b/deprecated/transit/transit.go
@@ -128,7 +128,7 @@ type ServiceType string
 // Possible Types
 const (
 	Process ServiceType = "Process"
-	Service             = "Service"
+	Service ServiceType = "Service"
 )
 
 // GroupType defines the foundation group type
@@ -147,10 +147,10 @@ type MetricSampleType string
 // TimeSeries Metric Sample Possible Types
 const (
 	Value    MetricSampleType = "Value"
-	Warning                   = "Warning"
-	Critical                  = "Critical"
-	Min                       = "Min"
-	Max                       = "Max"
+	Warning  MetricSampleType = "Warning"
+	Critical MetricSampleType = "Critical"
+	Min      MetricSampleType = "Min"
+	Max      MetricSampleType = "Max"
 )
 
 // TimeInterval defines a closed time interval. It extends from the start time

--- a/integration/apiclient.go
+++ b/integration/apiclient.go
@@ -64,11 +64,11 @@ func (c *APIClient) CheckHostExist(host string, mustExist bool, mustHasStatus st
 		return fmt.Errorf("status code = %d (Details: %s), want = %d ", statusCode, string(byteResponse), 200)
 	}
 
-	response := new(struct {
+	var response struct {
 		HostName      string `json:"hostName"`
 		MonitorStatus string `json:"monitorStatus"`
-	})
-	if err := json.Unmarshal(byteResponse, response); err != nil {
+	}
+	if err := json.Unmarshal(byteResponse, &response); err != nil {
 		return err
 	}
 

--- a/integration/integration.go
+++ b/integration/integration.go
@@ -149,7 +149,7 @@ func makeResource(rsIdx, svcCount int, opts ...OV) transit.MonitoredResource {
 		}
 	}
 
-	rs := new(transit.MonitoredResource)
+	var rs transit.MonitoredResource
 	rs.Status = transit.HostUp
 	rs.Type = transit.ResourceTypeHost
 	rs.LastCheckTime = transit.NewTimestamp()
@@ -160,8 +160,10 @@ func makeResource(rsIdx, svcCount int, opts ...OV) transit.MonitoredResource {
 	rs.Description = strings.Join(
 		append([]string{strings.ToUpper(rs.Name)}, randStrs(rsIdx)...), " ")
 
+	var svc transit.MonitoredService
+	var m transit.TimeSeries
 	for i := 0; i < svcCount; i++ {
-		svc := new(transit.MonitoredService)
+		svc = transit.MonitoredService{}
 		svc.Name = fmt.Sprintf("%v.%v.%v", sPrefix, i, rs.Name)
 		svc.Owner = rs.Name
 		svc.Status = transit.ServiceOk
@@ -174,7 +176,7 @@ func makeResource(rsIdx, svcCount int, opts ...OV) transit.MonitoredResource {
 		svc.Description = strings.Join(
 			append([]string{strings.ToUpper(svc.Name)}, randStrs(i+rsIdx)...), " ")
 
-		m := new(transit.TimeSeries)
+		m = transit.TimeSeries{}
 		m.Interval = new(transit.TimeInterval)
 		m.Interval.StartTime = transit.NewTimestamp()
 		m.Interval.EndTime = transit.NewTimestamp()
@@ -183,11 +185,11 @@ func makeResource(rsIdx, svcCount int, opts ...OV) transit.MonitoredResource {
 		m.Value = transit.NewTypedValue(i)
 		m.Unit = transit.MB
 
-		svc.Metrics = append(svc.Metrics, *m)
-		rs.Services = append(rs.Services, *svc)
+		svc.Metrics = append(svc.Metrics, m)
+		rs.Services = append(rs.Services, svc)
 	}
 
-	return *rs
+	return rs
 }
 
 func randStrs(x ...int) []string {

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -29,10 +29,10 @@ func TestIntegration(t *testing.T) {
 		Type:        transit.HostGroup,
 	}
 	rs := makeResource(0, 3)
-	resources := new(transit.ResourcesWithServicesRequest)
+	var resources transit.ResourcesWithServicesRequest
 	resources.SetContext(services.GetTransitService().MakeTracerContext())
 	resources.AddResource(rs)
-	inventory := new(transit.InventoryRequest)
+	var inventory transit.InventoryRequest
 	inventory.SetContext(services.GetTransitService().MakeTracerContext())
 	inventory.AddResource(rs.ToInventoryResource())
 	group.AddResource(rs.ToResourceRef())
@@ -188,9 +188,9 @@ func inventoryRequest(countHst, countSvc int, opts ...OV) ([]byte, error) {
 		}
 	}
 
-	inventory := new(transit.InventoryRequest)
+	var inventory transit.InventoryRequest
 	inventory.SetContext(services.GetTransitService().MakeTracerContext())
-	hg1, hg2 := new(transit.ResourceGroup), new(transit.ResourceGroup)
+	var hg1, hg2 transit.ResourceGroup
 
 	for i, rs := range resources(countHst, countSvc, opts...) {
 		inventory.AddResource(rs.ToInventoryResource())
@@ -200,15 +200,15 @@ func inventoryRequest(countHst, countSvc int, opts ...OV) ([]byte, error) {
 			hg1.Type = transit.HostGroup
 			hg1.GroupName = fmt.Sprintf("%v.%v.%v", group1, TestEntityName, i)
 			hg1.Description = fmt.Sprintf("%v %v %v", group1, TestEntityName, i)
-			inventory.AddResourceGroup(*hg1)
-			hg1 = new(transit.ResourceGroup)
+			inventory.AddResourceGroup(hg1)
+			hg1 = transit.ResourceGroup{}
 		}
 		if i%10 == 0 {
 			hg2.Type = transit.HostGroup
 			hg2.GroupName = fmt.Sprintf("%v.%v.%v", group2, TestEntityName, i)
 			hg2.Description = fmt.Sprintf("%v %v %v", group2, TestEntityName, i)
-			inventory.AddResourceGroup(*hg2)
-			hg2 = new(transit.ResourceGroup)
+			inventory.AddResourceGroup(hg2)
+			hg2 = transit.ResourceGroup{}
 		}
 	}
 
@@ -217,16 +217,16 @@ func inventoryRequest(countHst, countSvc int, opts ...OV) ([]byte, error) {
 
 // inspired by expvar.Handler() implementation
 func memstats() any {
-	stats := new(runtime.MemStats)
-	runtime.ReadMemStats(stats)
-	return *stats
+	var stats runtime.MemStats
+	runtime.ReadMemStats(&stats)
+	return stats
 }
 func printMemStats() {
 	println("\n~", time.Now().Format(time.DateTime), "MEM_STATS", fmt.Sprintf("%+v", memstats()))
 }
 func printExpvar() {
 	// println("\n~", time.Now().Format(time.DateTime), "TCG_STATS", fmt.Sprintf("%+v", services.GetTransitService().Stats()))
-	buf := new(bytes.Buffer)
-	expvar.Do(func(kv expvar.KeyValue) { fmt.Fprintln(buf, kv.Key+": "+kv.Value.String()) })
+	var buf bytes.Buffer
+	expvar.Do(func(kv expvar.KeyValue) { fmt.Fprintln(&buf, kv.Key+": "+kv.Value.String()) })
 	println("\n~", time.Now().Format(time.DateTime), "TCG_EXPVAR", "\n", buf.String())
 }

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -30,10 +30,10 @@ func TestIntegration(t *testing.T) {
 	}
 	rs := makeResource(0, 3)
 	resources := new(transit.ResourcesWithServicesRequest)
-	resources.SetContext(*services.GetTransitService().MakeTracerContext())
+	resources.SetContext(services.GetTransitService().MakeTracerContext())
 	resources.AddResource(rs)
 	inventory := new(transit.InventoryRequest)
-	inventory.SetContext(*services.GetTransitService().MakeTracerContext())
+	inventory.SetContext(services.GetTransitService().MakeTracerContext())
 	inventory.AddResource(rs.ToInventoryResource())
 	group.AddResource(rs.ToResourceRef())
 	inventory.AddResourceGroup(group)
@@ -189,7 +189,7 @@ func inventoryRequest(countHst, countSvc int, opts ...OV) ([]byte, error) {
 	}
 
 	inventory := new(transit.InventoryRequest)
-	inventory.SetContext(*services.GetTransitService().MakeTracerContext())
+	inventory.SetContext(services.GetTransitService().MakeTracerContext())
 	hg1, hg2 := new(transit.ResourceGroup), new(transit.ResourceGroup)
 
 	for i, rs := range resources(countHst, countSvc, opts...) {

--- a/libtransit/.gitignore
+++ b/libtransit/.gitignore
@@ -1,4 +1,4 @@
 *.h
 *.so
 *.run
-hgen
+hgen/hgen

--- a/libtransit/Makefile
+++ b/libtransit/Makefile
@@ -22,19 +22,27 @@ INCLUDES = -I./
 # We use "-g" because it helps with running under gdb when we experience segfaults.
 CFLAGS = ${INCLUDES} -m64 -std=gnu11 -g
 
-all: echo libtransit.h libtransit.so transit.h examples
+all		: echo \
+    transit.h \
+    libtransit.h libtransit.so\
+    libtransit_compat.h \
+	examples
 
-echo:
+echo	:
 	@echo Build info: ${BUILD_TAG} / ${BUILD_TIME}
 
 run_examples: examples
 	@echo Running examples
 	LIBTRANSIT=./libtransit.so ./example_dl.run
 
-examples: libtransit.h libtransit.so transit.h ./examples/c/*.c
+examples	: libtransit.so libtransit.h transit.h ./examples/c/*.c
 	${CC} ${CFLAGS} -o example_dl.run ./examples/c/example_dl.c -ldl
 
-# Build shared lib and set build info values with Go linker
+# Build header with constants definitions
+transit.h	: ../sdk/transit/*.go
+	go run ./tools/hgen/ --folders ../sdk/transit
+
+# Build shared lib with build info
 libtransit.h libtransit.so	: ../*/*.go ../*/*/*.go
 	go build \
 		-ldflags "-X 'github.com/gwos/tcg/config.buildTag=${BUILD_TAG}' \
@@ -42,11 +50,13 @@ libtransit.h libtransit.so	: ../*/*.go ../*/*/*.go
 		-buildmode=c-shared -o libtransit.so ./
 	chmod +x libtransit.so
 
-# Build additional header
-transit.h: ../sdk/transit/*.go
-	go run ./tools/hgen/ --folders ../sdk/transit
+# Build combined header for compatibility
+libtransit_compat.h	: libtransit.h transit.h
+	cat transit.h > libtransit_compat.h
+	echo >> libtransit_compat.h
+	cat libtransit.h >> libtransit_compat.h
 
-clean:
+clean	:
 	rm -rf *.h *.so *.run
 
 distclean: clean

--- a/libtransit/downtimes.go
+++ b/libtransit/downtimes.go
@@ -3,6 +3,8 @@ package main
 /*
 #include <stdbool.h>
 #include <stdint.h>
+
+typedef const char cchar_t;
 */
 import "C"
 import (
@@ -24,11 +26,10 @@ func CreateDowntimes() C.uintptr_t {
 // AddDowntime appends HostServiceInDowntime value to target.
 //
 //export AddDowntime
-func AddDowntime(target C.uintptr_t,
-	entityType *C.char,
-	entityName *C.char,
-	hostName *C.char,
-	serviceDesc *C.char,
+func AddDowntime(
+	target C.uintptr_t,
+	entityType, entityName,
+	hostName, serviceDesc *C.cchar_t,
 	scheduledDepth C.int,
 ) {
 	h := cgo.Handle(target)
@@ -61,11 +62,11 @@ func CreateDowntimesRequest() C.uintptr_t {
 // It skips NULL params.
 //
 //export ExtendDowntimesRequest
-func ExtendDowntimesRequest(target C.uintptr_t,
-	hostName,
-	hostGroup,
-	serviceDesc,
-	serviceGroup *C.char) {
+func ExtendDowntimesRequest(
+	target C.uintptr_t,
+	hostName, hostGroup,
+	serviceDesc, serviceGroup *C.cchar_t,
+) {
 	h := cgo.Handle(target)
 	if hv, ok := h.Value().(*transit.DowntimesRequest); ok {
 		if hostName != nil {

--- a/libtransit/events.go
+++ b/libtransit/events.go
@@ -3,6 +3,8 @@ package main
 /*
 #include <stdbool.h>
 #include <stdint.h>
+
+typedef const char cchar_t;
 */
 import "C"
 import (
@@ -17,7 +19,7 @@ import (
 //
 //export CreateEvent
 func CreateEvent(
-	appType, host, monStatus *C.char,
+	appType, host, monStatus *C.cchar_t,
 	sec, nsec C.longlong,
 ) C.uintptr_t {
 	p := new(transit.GroundworkEvent)
@@ -54,9 +56,9 @@ func SetEventAttrs(target C.uintptr_t,
 	errorType,
 	loggerName,
 	logType,
-	monServer *C.char,
+	monServer *C.cchar_t,
 ) {
-	attr := func(k *string, v *C.char) {
+	attr := func(k *string, v *C.cchar_t) {
 		if v != nil {
 			*k = C.GoString(v)
 		}
@@ -154,7 +156,7 @@ func CreateEventsAckRequest() C.uintptr_t {
 //export AddEventAck
 func AddEventAck(
 	target C.uintptr_t,
-	appType, host, service, ackBy, ackComment *C.char,
+	appType, host, service, ackBy, ackComment *C.cchar_t,
 ) {
 	h := cgo.Handle(target)
 	if hv, ok := h.Value().(*transit.GroundworkEventsAckRequest); ok {
@@ -183,7 +185,7 @@ func CreateEventsUnackRequest() C.uintptr_t {
 //export AddEventUnack
 func AddEventUnack(
 	target C.uintptr_t,
-	appType, host, service *C.char,
+	appType, host, service *C.cchar_t,
 ) {
 	h := cgo.Handle(target)
 	if hv, ok := h.Value().(*transit.GroundworkEventsUnackRequest); ok {

--- a/libtransit/libtransit.go
+++ b/libtransit/libtransit.go
@@ -3,6 +3,8 @@ package main
 /*
 #include <stdbool.h>
 #include <stdint.h>
+
+typedef const char cchar_t;
 */
 import "C"
 import (
@@ -32,7 +34,7 @@ func CreateInventoryRequest() C.uintptr_t {
 // It returns a handle that should be deleted after use with DeleteHandle.
 //
 //export CreateInventoryResource
-func CreateInventoryResource(name *C.char, resType *C.char) C.uintptr_t {
+func CreateInventoryResource(name, resType *C.cchar_t) C.uintptr_t {
 	p := new(transit.InventoryResource)
 	p.Name = C.GoString(name)
 	p.Type = transit.ResourceType(C.GoString(resType))
@@ -44,7 +46,7 @@ func CreateInventoryResource(name *C.char, resType *C.char) C.uintptr_t {
 // It returns a handle that should be deleted after use with DeleteHandle.
 //
 //export CreateInventoryService
-func CreateInventoryService(name *C.char, resType *C.char) C.uintptr_t {
+func CreateInventoryService(name, resType *C.cchar_t) C.uintptr_t {
 	p := new(transit.InventoryService)
 	p.Name = C.GoString(name)
 	p.Type = transit.ResourceType(C.GoString(resType))
@@ -55,7 +57,7 @@ func CreateInventoryService(name *C.char, resType *C.char) C.uintptr_t {
 // It returns a handle that should be deleted after use with DeleteHandle.
 //
 //export CreateMonitoredResource
-func CreateMonitoredResource(name *C.char, resType *C.char) C.uintptr_t {
+func CreateMonitoredResource(name, resType *C.cchar_t) C.uintptr_t {
 	p := new(transit.MonitoredResource)
 	p.Name = C.GoString(name)
 	p.Type = transit.ResourceType(C.GoString(resType))
@@ -67,7 +69,7 @@ func CreateMonitoredResource(name *C.char, resType *C.char) C.uintptr_t {
 // It returns a handle that should be deleted after use with DeleteHandle.
 //
 //export CreateMonitoredService
-func CreateMonitoredService(name *C.char, resType *C.char) C.uintptr_t {
+func CreateMonitoredService(name, resType *C.cchar_t) C.uintptr_t {
 	p := new(transit.MonitoredService)
 	p.Name = C.GoString(name)
 	p.Type = transit.ResourceType(C.GoString(resType))
@@ -79,7 +81,7 @@ func CreateMonitoredService(name *C.char, resType *C.char) C.uintptr_t {
 // It returns a handle that should be deleted after use with DeleteHandle.
 //
 //export CreateResourceGroup
-func CreateResourceGroup(name *C.char, grType *C.char) C.uintptr_t {
+func CreateResourceGroup(name, grType *C.cchar_t) C.uintptr_t {
 	p := new(transit.ResourceGroup)
 	p.GroupName = C.GoString(name)
 	p.Type = transit.GroupType(C.GoString(grType))
@@ -102,10 +104,7 @@ func CreateResourcesWithServicesRequest() C.uintptr_t {
 // It returns a handle that should be deleted after use with DeleteHandle.
 //
 //export CreateThresholdValue
-func CreateThresholdValue(
-	lbl *C.char,
-	sType *C.char,
-) C.uintptr_t {
+func CreateThresholdValue(lbl, sType *C.cchar_t) C.uintptr_t {
 	p := new(transit.ThresholdValue)
 	p.Label = C.GoString(lbl)
 	p.SampleType = transit.MetricSampleType(C.GoString(sType))
@@ -116,9 +115,7 @@ func CreateThresholdValue(
 // It returns a handle that should be deleted after use with DeleteHandle.
 //
 //export CreateTimeSeries
-func CreateTimeSeries(
-	name *C.char,
-) C.uintptr_t {
+func CreateTimeSeries(name *C.cchar_t) C.uintptr_t {
 	p := new(transit.TimeSeries)
 	p.MetricName = C.GoString(name)
 	return C.uintptr_t(cgo.NewHandle(p))
@@ -135,7 +132,7 @@ func DeleteHandle(target C.uintptr_t) {
 // AddMetric appends metric value to target
 //
 //export AddMetric
-func AddMetric(target C.uintptr_t, value C.uintptr_t) {
+func AddMetric(target, value C.uintptr_t) {
 	h, h2 := cgo.Handle(target), cgo.Handle(value)
 	if hv, ok := h.Value().(interface{ AddMetric(transit.TimeSeries) }); ok {
 		if hv2, ok := h2.Value().(*transit.TimeSeries); ok {
@@ -147,7 +144,7 @@ func AddMetric(target C.uintptr_t, value C.uintptr_t) {
 // AddResource appends resource value to target
 //
 //export AddResource
-func AddResource(target C.uintptr_t, value C.uintptr_t) {
+func AddResource(target, value C.uintptr_t) {
 	h, h2 := cgo.Handle(target), cgo.Handle(value)
 	if hv, ok := h.Value().(interface {
 		AddResource(transit.InventoryResource)
@@ -180,7 +177,7 @@ func AddResource(target C.uintptr_t, value C.uintptr_t) {
 // AddResourceGroup appends resource group value to target
 //
 //export AddResourceGroup
-func AddResourceGroup(target C.uintptr_t, value C.uintptr_t) {
+func AddResourceGroup(target, value C.uintptr_t) {
 	h, h2 := cgo.Handle(target), cgo.Handle(value)
 	if hv, ok := h.Value().(interface{ AddResourceGroup(transit.ResourceGroup) }); ok {
 		if hv2, ok := h2.Value().(*transit.ResourceGroup); ok {
@@ -193,7 +190,7 @@ func AddResourceGroup(target C.uintptr_t, value C.uintptr_t) {
 // AddService appends service value to target
 //
 //export AddService
-func AddService(target C.uintptr_t, value C.uintptr_t) {
+func AddService(target, value C.uintptr_t) {
 	h, h2 := cgo.Handle(target), cgo.Handle(value)
 	if hv, ok := h.Value().(interface {
 		AddService(transit.InventoryService)
@@ -216,7 +213,7 @@ func AddService(target C.uintptr_t, value C.uintptr_t) {
 // AddThreshold appends threshold value to target
 //
 //export AddThreshold
-func AddThreshold(target C.uintptr_t, value C.uintptr_t) {
+func AddThreshold(target, value C.uintptr_t) {
 	h, h2 := cgo.Handle(target), cgo.Handle(value)
 	if hv, ok := h.Value().(interface{ AddThreshold(transit.ThresholdValue) }); ok {
 		if hv2, ok := h2.Value().(*transit.ThresholdValue); ok {
@@ -228,7 +225,7 @@ func AddThreshold(target C.uintptr_t, value C.uintptr_t) {
 // AddThresholdDouble appends threshold to target
 //
 //export AddThresholdDouble
-func AddThresholdDouble(target C.uintptr_t, lbl, sType *C.char, value C.double) {
+func AddThresholdDouble(target C.uintptr_t, lbl, sType *C.cchar_t, value C.double) {
 	h := cgo.Handle(target)
 	if hv, ok := h.Value().(interface{ AddThreshold(transit.ThresholdValue) }); ok {
 		hv.AddThreshold(transit.ThresholdValue{
@@ -242,7 +239,7 @@ func AddThresholdDouble(target C.uintptr_t, lbl, sType *C.char, value C.double) 
 // AddThresholdInt appends threshold to target
 //
 //export AddThresholdInt
-func AddThresholdInt(target C.uintptr_t, lbl, sType *C.char, value C.longlong) {
+func AddThresholdInt(target C.uintptr_t, lbl, sType *C.cchar_t, value C.longlong) {
 	h := cgo.Handle(target)
 	if hv, ok := h.Value().(interface{ AddThreshold(transit.ThresholdValue) }); ok {
 		hv.AddThreshold(transit.ThresholdValue{
@@ -280,7 +277,7 @@ func CalcStatus(target C.uintptr_t) {
 // SetCategory sets category value on target
 //
 //export SetCategory
-func SetCategory(target C.uintptr_t, value *C.char) {
+func SetCategory(target C.uintptr_t, value *C.cchar_t) {
 	h := cgo.Handle(target)
 	if hv, ok := h.Value().(interface{ SetCategory(string) }); ok {
 		hv.SetCategory(C.GoString(value))
@@ -302,7 +299,7 @@ func SetContextTimestamp(target C.uintptr_t, sec, nsec C.longlong) {
 // SetContextToken sets context token value on target
 //
 //export SetContextToken
-func SetContextToken(target C.uintptr_t, value *C.char) {
+func SetContextToken(target C.uintptr_t, value *C.cchar_t) {
 	h := cgo.Handle(target)
 	if hv, ok := h.Value().(interface{ SetContext(transit.TracerContext) }); ok {
 		hv.SetContext(transit.TracerContext{TraceToken: C.GoString(value)})
@@ -312,7 +309,7 @@ func SetContextToken(target C.uintptr_t, value *C.char) {
 // SetDescription sets description value on target
 //
 //export SetDescription
-func SetDescription(target C.uintptr_t, value *C.char) {
+func SetDescription(target C.uintptr_t, value *C.cchar_t) {
 	h := cgo.Handle(target)
 	if hv, ok := h.Value().(interface{ SetDescription(string) }); ok {
 		hv.SetDescription(C.GoString(value))
@@ -356,7 +353,7 @@ func SetIntervalStart(target C.uintptr_t, sec, nsec C.longlong) {
 // SetLastPluginOutput sets LastPluginOutput value on target
 //
 //export SetLastPluginOutput
-func SetLastPluginOutput(target C.uintptr_t, value *C.char) {
+func SetLastPluginOutput(target C.uintptr_t, value *C.cchar_t) {
 	h := cgo.Handle(target)
 	if hv, ok := h.Value().(interface{ SetLastPluginOutput(string) }); ok {
 		hv.SetLastPluginOutput(C.GoString(value))
@@ -390,7 +387,7 @@ func SetNextCheckTime(target C.uintptr_t, sec, nsec C.longlong) {
 // SetName sets name value on target
 //
 //export SetName
-func SetName(target C.uintptr_t, value *C.char) {
+func SetName(target C.uintptr_t, value *C.cchar_t) {
 	h := cgo.Handle(target)
 	if hv, ok := h.Value().(interface{ SetName(string) }); ok {
 		hv.SetName(C.GoString(value))
@@ -400,7 +397,7 @@ func SetName(target C.uintptr_t, value *C.char) {
 // SetOwner sets owner value on target
 //
 //export SetOwner
-func SetOwner(target C.uintptr_t, value *C.char) {
+func SetOwner(target C.uintptr_t, value *C.cchar_t) {
 	h := cgo.Handle(target)
 	if hv, ok := h.Value().(interface{ SetOwner(string) }); ok {
 		hv.SetOwner(C.GoString(value))
@@ -410,7 +407,7 @@ func SetOwner(target C.uintptr_t, value *C.char) {
 // SetPropertyBool sets key:value property on target
 //
 //export SetPropertyBool
-func SetPropertyBool(target C.uintptr_t, key *C.char, value C.bool) {
+func SetPropertyBool(target C.uintptr_t, key *C.cchar_t, value C.bool) {
 	h := cgo.Handle(target)
 	if hv, ok := h.Value().(interface{ SetProperty(string, interface{}) }); ok {
 		hv.SetProperty(C.GoString(key), bool(value))
@@ -420,7 +417,7 @@ func SetPropertyBool(target C.uintptr_t, key *C.char, value C.bool) {
 // SetPropertyDouble sets key:value property on target
 //
 //export SetPropertyDouble
-func SetPropertyDouble(target C.uintptr_t, key *C.char, value C.double) {
+func SetPropertyDouble(target C.uintptr_t, key *C.cchar_t, value C.double) {
 	h := cgo.Handle(target)
 	if hv, ok := h.Value().(interface{ SetProperty(string, interface{}) }); ok {
 		hv.SetProperty(C.GoString(key), float64(value))
@@ -430,7 +427,7 @@ func SetPropertyDouble(target C.uintptr_t, key *C.char, value C.double) {
 // SetPropertyInt sets key:value property on target
 //
 //export SetPropertyInt
-func SetPropertyInt(target C.uintptr_t, key *C.char, value C.longlong) {
+func SetPropertyInt(target C.uintptr_t, key *C.cchar_t, value C.longlong) {
 	h := cgo.Handle(target)
 	if hv, ok := h.Value().(interface{ SetProperty(string, interface{}) }); ok {
 		hv.SetProperty(C.GoString(key), int64(value))
@@ -440,7 +437,7 @@ func SetPropertyInt(target C.uintptr_t, key *C.char, value C.longlong) {
 // SetPropertyStr sets key:value property on target
 //
 //export SetPropertyStr
-func SetPropertyStr(target C.uintptr_t, key *C.char, value *C.char) {
+func SetPropertyStr(target C.uintptr_t, key, value *C.cchar_t) {
 	h := cgo.Handle(target)
 	if hv, ok := h.Value().(interface{ SetProperty(string, interface{}) }); ok {
 		hv.SetProperty(C.GoString(key), C.GoString(value))
@@ -450,7 +447,7 @@ func SetPropertyStr(target C.uintptr_t, key *C.char, value *C.char) {
 // SetPropertyTime sets key:timestamp property on target
 //
 //export SetPropertyTime
-func SetPropertyTime(target C.uintptr_t, key *C.char, sec, nsec C.longlong) {
+func SetPropertyTime(target C.uintptr_t, key *C.cchar_t, sec, nsec C.longlong) {
 	h := cgo.Handle(target)
 	if hv, ok := h.Value().(interface{ SetProperty(string, interface{}) }); ok {
 		hv.SetProperty(C.GoString(key),
@@ -461,7 +458,7 @@ func SetPropertyTime(target C.uintptr_t, key *C.char, sec, nsec C.longlong) {
 // SetSampleType sets status value on target
 //
 //export SetSampleType
-func SetSampleType(target C.uintptr_t, value *C.char) {
+func SetSampleType(target C.uintptr_t, value *C.cchar_t) {
 	h := cgo.Handle(target)
 	if hv, ok := h.Value().(interface {
 		SetSampleType(transit.MetricSampleType)
@@ -473,7 +470,7 @@ func SetSampleType(target C.uintptr_t, value *C.char) {
 // SetStatus sets status value on target
 //
 //export SetStatus
-func SetStatus(target C.uintptr_t, value *C.char) {
+func SetStatus(target C.uintptr_t, value *C.cchar_t) {
 	h := cgo.Handle(target)
 	if hv, ok := h.Value().(interface{ SetStatus(transit.MonitorStatus) }); ok {
 		hv.SetStatus(transit.MonitorStatus(C.GoString(value)))
@@ -483,7 +480,7 @@ func SetStatus(target C.uintptr_t, value *C.char) {
 // SetTag sets key:value tag on target
 //
 //export SetTag
-func SetTag(target C.uintptr_t, key, value *C.char) {
+func SetTag(target C.uintptr_t, key, value *C.cchar_t) {
 	h := cgo.Handle(target)
 	if hv, ok := h.Value().(interface{ SetTag(string, string) }); ok {
 		hv.SetTag(C.GoString(key), C.GoString(value))
@@ -493,7 +490,7 @@ func SetTag(target C.uintptr_t, key, value *C.char) {
 // SetType sets type value on target
 //
 //export SetType
-func SetType(target C.uintptr_t, value *C.char) {
+func SetType(target C.uintptr_t, value *C.cchar_t) {
 	h := cgo.Handle(target)
 	if hv, ok := h.Value().(interface{ SetType(transit.GroupType) }); ok {
 		hv.SetType(transit.GroupType(C.GoString(value)))
@@ -508,7 +505,7 @@ func SetType(target C.uintptr_t, value *C.char) {
 // SetUnit sets type value on target
 //
 //export SetUnit
-func SetUnit(target C.uintptr_t, value *C.char) {
+func SetUnit(target C.uintptr_t, value *C.cchar_t) {
 	h := cgo.Handle(target)
 	if hv, ok := h.Value().(interface{ SetUnit(transit.UnitType) }); ok {
 		hv.SetUnit(transit.UnitType(C.GoString(value)))
@@ -548,7 +545,7 @@ func SetValueInt(target C.uintptr_t, value C.longlong) {
 // SetValueStr sets value to target
 //
 //export SetValueStr
-func SetValueStr(target C.uintptr_t, value *C.char) {
+func SetValueStr(target C.uintptr_t, value *C.cchar_t) {
 	h := cgo.Handle(target)
 	if hv, ok := h.Value().(interface{ SetValue(interface{}) }); ok {
 		hv.SetValue(C.GoString(value))
@@ -573,7 +570,7 @@ func SetValueTime(target C.uintptr_t, sec, nsec C.longlong) {
 //export MarshallIndentJSON
 func MarshallIndentJSON(
 	target C.uintptr_t,
-	prefix *C.char, indent *C.char,
+	prefix, indent *C.cchar_t,
 	buf *C.char, bufLen C.size_t,
 	errBuf *C.char, errBufLen C.size_t,
 ) C.bool {

--- a/libtransit/libtransit.go
+++ b/libtransit/libtransit.go
@@ -632,10 +632,10 @@ func Send(req C.uintptr_t, errBuf *C.char, errBufLen C.size_t) C.bool {
 	return true
 }
 
-// Sync processes inventory
+// SyncExt processes extended inventory included additional properties
 //
-//export Sync
-func Sync(p C.uintptr_t, errBuf *C.char, errBufLen C.size_t) C.bool {
+//export SyncExt
+func SyncExt(p C.uintptr_t, errBuf *C.char, errBufLen C.size_t) C.bool {
 	var inv *transit.InventoryRequest
 	h := cgo.Handle(p)
 	if v, ok := h.Value().(*transit.InventoryRequest); ok {
@@ -647,7 +647,7 @@ func Sync(p C.uintptr_t, errBuf *C.char, errBufLen C.size_t) C.bool {
 		return false
 	}
 
-	if err := services.GetTransitService().Sync(context.Background(), inv); err != nil {
+	if err := services.GetTransitService().SyncExt(context.Background(), inv); err != nil {
 		bufStr(errBuf, errBufLen, err.Error())
 		return false
 	}

--- a/libtransit/libtransit_tst.go
+++ b/libtransit/libtransit_tst.go
@@ -68,7 +68,7 @@ func testSetContextTimestamp(t *testing.T) {
 			h.Delete()
 			r := reflect.ValueOf(it.target)
 			f := reflect.Indirect(r).FieldByName(it.field)
-			assert.Equal(t, v, f.Interface().(*transit.TracerContext).TimeStamp.String())
+			assert.Equal(t, v, f.Interface().(transit.TracerContext).TimeStamp.String())
 		})
 	}
 }
@@ -95,7 +95,7 @@ func testSetContextToken(t *testing.T) {
 			h.Delete()
 			r := reflect.ValueOf(it.target)
 			f := reflect.Indirect(r).FieldByName(it.field)
-			assert.Equal(t, value, f.Interface().(*transit.TracerContext).TraceToken)
+			assert.Equal(t, value, f.Interface().(transit.TracerContext).TraceToken)
 		})
 	}
 }

--- a/libtransit/transitjson.go
+++ b/libtransit/transitjson.go
@@ -2,6 +2,8 @@ package main
 
 /*
 #include <stdbool.h>
+
+typedef const char cchar_t;
 */
 import "C"
 import (
@@ -34,7 +36,7 @@ func GetAgentIdentity(buf *C.char, bufLen C.size_t, errBuf *C.char, errBufLen C.
 // ClearInDowntime is a C API for services.GetTransitService().ClearInDowntime
 //
 //export ClearInDowntime
-func ClearInDowntime(payloadJSON, errBuf *C.char, errBufLen C.size_t) C.bool {
+func ClearInDowntime(payloadJSON *C.cchar_t, errBuf *C.char, errBufLen C.size_t) C.bool {
 	if err := services.GetTransitService().
 		ClearInDowntime(context.Background(), []byte(C.GoString(payloadJSON))); err != nil {
 		bufStr(errBuf, errBufLen, err.Error())
@@ -46,7 +48,7 @@ func ClearInDowntime(payloadJSON, errBuf *C.char, errBufLen C.size_t) C.bool {
 // SetInDowntime is a C API for services.GetTransitService().SetInDowntime
 //
 //export SetInDowntime
-func SetInDowntime(payloadJSON, errBuf *C.char, errBufLen C.size_t) C.bool {
+func SetInDowntime(payloadJSON *C.cchar_t, errBuf *C.char, errBufLen C.size_t) C.bool {
 	if err := services.GetTransitService().
 		SetInDowntime(context.Background(), []byte(C.GoString(payloadJSON))); err != nil {
 		bufStr(errBuf, errBufLen, err.Error())
@@ -58,7 +60,7 @@ func SetInDowntime(payloadJSON, errBuf *C.char, errBufLen C.size_t) C.bool {
 // SendEvents is a C API for services.GetTransitService().SendEvents
 //
 //export SendEvents
-func SendEvents(payloadJSON, errBuf *C.char, errBufLen C.size_t) C.bool {
+func SendEvents(payloadJSON *C.cchar_t, errBuf *C.char, errBufLen C.size_t) C.bool {
 	if err := services.GetTransitService().
 		SendEvents(context.Background(), []byte(C.GoString(payloadJSON))); err != nil {
 		bufStr(errBuf, errBufLen, err.Error())
@@ -70,7 +72,7 @@ func SendEvents(payloadJSON, errBuf *C.char, errBufLen C.size_t) C.bool {
 // SendEventsAck is a C API for services.GetTransitService().SendEventsAck
 //
 //export SendEventsAck
-func SendEventsAck(payloadJSON, errBuf *C.char, errBufLen C.size_t) C.bool {
+func SendEventsAck(payloadJSON *C.cchar_t, errBuf *C.char, errBufLen C.size_t) C.bool {
 	if err := services.GetTransitService().
 		SendEventsAck(context.Background(), []byte(C.GoString(payloadJSON))); err != nil {
 		bufStr(errBuf, errBufLen, err.Error())
@@ -82,7 +84,7 @@ func SendEventsAck(payloadJSON, errBuf *C.char, errBufLen C.size_t) C.bool {
 // SendEventsUnack is a C API for services.GetTransitService().SendEventsUnack
 //
 //export SendEventsUnack
-func SendEventsUnack(payloadJSON, errBuf *C.char, errBufLen C.size_t) C.bool {
+func SendEventsUnack(payloadJSON *C.cchar_t, errBuf *C.char, errBufLen C.size_t) C.bool {
 	if err := services.GetTransitService().
 		SendEventsUnack(context.Background(), []byte(C.GoString(payloadJSON))); err != nil {
 		bufStr(errBuf, errBufLen, err.Error())
@@ -94,7 +96,7 @@ func SendEventsUnack(payloadJSON, errBuf *C.char, errBufLen C.size_t) C.bool {
 // SendResourcesWithMetrics is a C API for services.GetTransitService().SendResourceWithMetrics
 //
 //export SendResourcesWithMetrics
-func SendResourcesWithMetrics(payloadJSON, errBuf *C.char, errBufLen C.size_t) C.bool {
+func SendResourcesWithMetrics(payloadJSON *C.cchar_t, errBuf *C.char, errBufLen C.size_t) C.bool {
 	if err := services.GetTransitService().
 		SendResourceWithMetrics(context.Background(), []byte(C.GoString(payloadJSON))); err != nil {
 		bufStr(errBuf, errBufLen, err.Error())
@@ -106,7 +108,7 @@ func SendResourcesWithMetrics(payloadJSON, errBuf *C.char, errBufLen C.size_t) C
 // SynchronizeInventory is a C API for services.GetTransitService().SynchronizeInventory
 //
 //export SynchronizeInventory
-func SynchronizeInventory(payloadJSON, errBuf *C.char, errBufLen C.size_t) C.bool {
+func SynchronizeInventory(payloadJSON *C.cchar_t, errBuf *C.char, errBufLen C.size_t) C.bool {
 	if err := services.GetTransitService().
 		SynchronizeInventory(context.Background(), []byte(C.GoString(payloadJSON))); err != nil {
 		bufStr(errBuf, errBufLen, err.Error())
@@ -118,7 +120,7 @@ func SynchronizeInventory(payloadJSON, errBuf *C.char, errBufLen C.size_t) C.boo
 // SynchronizeInventoryExt is a C API for services.GetTransitService().SynchronizeInventoryExt
 //
 //export SynchronizeInventoryExt
-func SynchronizeInventoryExt(payloadJSON, errBuf *C.char, errBufLen C.size_t) C.bool {
+func SynchronizeInventoryExt(payloadJSON *C.cchar_t, errBuf *C.char, errBufLen C.size_t) C.bool {
 	if err := services.GetTransitService().
 		SynchronizeInventoryExt(context.Background(), []byte(C.GoString(payloadJSON))); err != nil {
 		bufStr(errBuf, errBufLen, err.Error())

--- a/libtransit/transitjson.go
+++ b/libtransit/transitjson.go
@@ -114,3 +114,15 @@ func SynchronizeInventory(payloadJSON, errBuf *C.char, errBufLen C.size_t) C.boo
 	}
 	return true
 }
+
+// SynchronizeInventoryExt is a C API for services.GetTransitService().SynchronizeInventoryExt
+//
+//export SynchronizeInventoryExt
+func SynchronizeInventoryExt(payloadJSON, errBuf *C.char, errBufLen C.size_t) C.bool {
+	if err := services.GetTransitService().
+		SynchronizeInventoryExt(context.Background(), []byte(C.GoString(payloadJSON))); err != nil {
+		bufStr(errBuf, errBufLen, err.Error())
+		return false
+	}
+	return true
+}

--- a/nats/dispatcher.go
+++ b/nats/dispatcher.go
@@ -140,8 +140,8 @@ func (d *natsDispatcher) fetch(ctx context.Context, opt DurableCfg, cons jetstre
 		if delayRetry != nil {
 			xRetryDelay.Set(fmt.Sprintf("%v / %v / %v", delayRetry.Retry, RetryDelays[delayRetry.Retry], time.Now().UTC().Format(time.RFC3339)))
 			log.Debug().
+				Stringer("delay", RetryDelays[delayRetry.Retry]).
 				Int("retry", delayRetry.Retry).
-				Str("delay", RetryDelays[delayRetry.Retry].String()).
 				Msg("dispatcher delaying retry")
 
 			select {

--- a/sdk/clients/gwClient.go
+++ b/sdk/clients/gwClient.go
@@ -164,13 +164,13 @@ func (client *GWClient) connectLocal() (string, error) {
 		"Content-Type": "application/x-www-form-urlencoded",
 	}
 
-	req := new(Req)
-	err := client.doReq(context.Background(), req, http.MethodPost, GWEntrypointConnect, "",
+	ctx, req := context.TODO(), Req{}
+	err := client.doReq(ctx, &req, http.MethodPost, GWEntrypointConnect, "",
 		headers, formValues, nil)
 
 	switch {
 	case err != nil:
-		sdklog.Logger.LogAttrs(context.Background(), slog.LevelError, "could not connect local groundwork", req.LogAttrs()...)
+		sdklog.Logger.LogAttrs(ctx, slog.LevelError, "could not connect local groundwork", req.LogAttrs()...)
 		if tcgerr.IsErrorDNS(err) || tcgerr.IsErrorConnection(err) || tcgerr.IsErrorTimedOut(err) {
 			return "", fmt.Errorf("%w: %v", tcgerr.ErrTransient, err.Error())
 		}
@@ -180,28 +180,28 @@ func (client *GWClient) connectLocal() (string, error) {
 		(req.Status == 404 && bytes.Contains(req.Response, []byte("password"))):
 		eee := fmt.Errorf("%w: %v", tcgerr.ErrUnauthorized, string(req.Response))
 		req.Err = eee
-		sdklog.Logger.LogAttrs(context.Background(), slog.LevelWarn, "could not connect local groundwork", req.LogAttrs()...)
+		sdklog.Logger.LogAttrs(ctx, slog.LevelWarn, "could not connect local groundwork", req.LogAttrs()...)
 		return "", eee
 
 	case req.Status == 502 || req.Status == 504:
 		eee := fmt.Errorf("%w: %v", tcgerr.ErrGateway, string(req.Response))
 		req.Err = eee
-		sdklog.Logger.LogAttrs(context.Background(), slog.LevelWarn, "could not connect local groundwork", req.LogAttrs()...)
+		sdklog.Logger.LogAttrs(ctx, slog.LevelWarn, "could not connect local groundwork", req.LogAttrs()...)
 		return "", eee
 
 	case req.Status == 503:
 		eee := fmt.Errorf("%w: %v", tcgerr.ErrSynchronizer, string(req.Response))
 		req.Err = eee
-		sdklog.Logger.LogAttrs(context.Background(), slog.LevelWarn, "could not connect local groundwork", req.LogAttrs()...)
+		sdklog.Logger.LogAttrs(ctx, slog.LevelWarn, "could not connect local groundwork", req.LogAttrs()...)
 		return "", eee
 
 	case req.Status != 200:
 		eee := fmt.Errorf("%w: %v", tcgerr.ErrUndecided, string(req.Response))
 		req.Err = eee
-		sdklog.Logger.LogAttrs(context.Background(), slog.LevelWarn, "could not connect local groundwork", req.Details()...)
+		sdklog.Logger.LogAttrs(ctx, slog.LevelWarn, "could not connect local groundwork", req.Details()...)
 		return "", eee
 	}
-	sdklog.Logger.LogAttrs(context.Background(), slog.LevelDebug, "connect local groundwork", req.LogAttrs()...)
+	sdklog.Logger.LogAttrs(ctx, slog.LevelDebug, "connect local groundwork", req.LogAttrs()...)
 	return string(req.Response), nil
 }
 
@@ -217,13 +217,13 @@ func (client *GWClient) AuthenticatePassword(username, password string) (string,
 		"GWOS-APP-NAME": client.AppName,
 	}
 
-	req := new(Req)
-	err := client.doReq(context.Background(), req, http.MethodPut, GWEntrypointAuthenticatePassword, "",
+	ctx, req := context.TODO(), Req{}
+	err := client.doReq(ctx, &req, http.MethodPut, GWEntrypointAuthenticatePassword, "",
 		headers, nil, payload)
 
 	switch {
 	case err != nil:
-		sdklog.Logger.LogAttrs(context.Background(), slog.LevelError, "could not authenticate password", req.LogAttrs()...)
+		sdklog.Logger.LogAttrs(ctx, slog.LevelError, "could not authenticate password", req.LogAttrs()...)
 		if tcgerr.IsErrorDNS(err) || tcgerr.IsErrorConnection(err) || tcgerr.IsErrorTimedOut(err) {
 			return "", fmt.Errorf("%w: %v", tcgerr.ErrTransient, err.Error())
 		}
@@ -233,25 +233,25 @@ func (client *GWClient) AuthenticatePassword(username, password string) (string,
 		(req.Status == 404 && bytes.Contains(req.Response, []byte("password"))):
 		eee := fmt.Errorf("%w: %v", tcgerr.ErrUnauthorized, string(req.Response))
 		req.Err = eee
-		sdklog.Logger.LogAttrs(context.Background(), slog.LevelWarn, "could not authenticate password", req.LogAttrs()...)
+		sdklog.Logger.LogAttrs(ctx, slog.LevelWarn, "could not authenticate password", req.LogAttrs()...)
 		return "", eee
 
 	case req.Status == 502 || req.Status == 504:
 		eee := fmt.Errorf("%w: %v", tcgerr.ErrGateway, string(req.Response))
 		req.Err = eee
-		sdklog.Logger.LogAttrs(context.Background(), slog.LevelWarn, "could not authenticate password", req.LogAttrs()...)
+		sdklog.Logger.LogAttrs(ctx, slog.LevelWarn, "could not authenticate password", req.LogAttrs()...)
 		return "", eee
 
 	case req.Status == 503:
 		eee := fmt.Errorf("%w: %v", tcgerr.ErrSynchronizer, string(req.Response))
 		req.Err = eee
-		sdklog.Logger.LogAttrs(context.Background(), slog.LevelWarn, "could not authenticate password", req.LogAttrs()...)
+		sdklog.Logger.LogAttrs(ctx, slog.LevelWarn, "could not authenticate password", req.LogAttrs()...)
 		return "", eee
 
 	case req.Status != 200:
 		eee := fmt.Errorf("%w: %v", tcgerr.ErrUndecided, string(req.Response))
 		req.Err = eee
-		sdklog.Logger.LogAttrs(context.Background(), slog.LevelWarn, "could not authenticate password", req.Details()...)
+		sdklog.Logger.LogAttrs(ctx, slog.LevelWarn, "could not authenticate password", req.Details()...)
 		return "", eee
 	}
 
@@ -261,10 +261,10 @@ func (client *GWClient) AuthenticatePassword(username, password string) (string,
 	}
 	user := UserResponse{AccessToken: ""}
 	if err := json.Unmarshal(req.Response, &user); err != nil {
-		sdklog.Logger.LogAttrs(context.Background(), slog.LevelWarn, fmt.Sprintf("could not authenticate password: parsingError: %s", err), req.Details()...)
+		sdklog.Logger.LogAttrs(ctx, slog.LevelWarn, fmt.Sprintf("could not authenticate password: parsingError: %s", err), req.Details()...)
 		return "", fmt.Errorf("%w: %v", tcgerr.ErrUndecided, err)
 	}
-	sdklog.Logger.LogAttrs(context.Background(), slog.LevelDebug, "authenticate password", req.LogAttrs()...)
+	sdklog.Logger.LogAttrs(ctx, slog.LevelDebug, "authenticate password", req.LogAttrs()...)
 	return user.AccessToken, nil
 }
 
@@ -279,13 +279,13 @@ func (client *GWClient) Disconnect() error {
 		"Content-Type": "application/x-www-form-urlencoded",
 	}
 
-	req := new(Req)
-	err := client.doReq(context.Background(), req, http.MethodPost, GWEntrypointDisconnect, "",
+	ctx, req := context.TODO(), Req{}
+	err := client.doReq(ctx, &req, http.MethodPost, GWEntrypointDisconnect, "",
 		headers, formValues, nil)
 
 	switch {
 	case err != nil:
-		sdklog.Logger.LogAttrs(context.Background(), slog.LevelError, "could not disconnect groundwork", req.LogAttrs()...)
+		sdklog.Logger.LogAttrs(ctx, slog.LevelError, "could not disconnect groundwork", req.LogAttrs()...)
 		if tcgerr.IsErrorDNS(err) || tcgerr.IsErrorConnection(err) || tcgerr.IsErrorTimedOut(err) {
 			return fmt.Errorf("%w: %v", tcgerr.ErrTransient, err.Error())
 		}
@@ -294,28 +294,28 @@ func (client *GWClient) Disconnect() error {
 	case req.Status == 401:
 		eee := fmt.Errorf("%w: %v", tcgerr.ErrUnauthorized, string(req.Response))
 		req.Err = eee
-		sdklog.Logger.LogAttrs(context.Background(), slog.LevelWarn, "could not disconnect groundwork", req.LogAttrs()...)
+		sdklog.Logger.LogAttrs(ctx, slog.LevelWarn, "could not disconnect groundwork", req.LogAttrs()...)
 		return eee
 
 	case req.Status == 502 || req.Status == 504:
 		eee := fmt.Errorf("%w: %v", tcgerr.ErrGateway, string(req.Response))
 		req.Err = eee
-		sdklog.Logger.LogAttrs(context.Background(), slog.LevelWarn, "could not disconnect groundwork", req.LogAttrs()...)
+		sdklog.Logger.LogAttrs(ctx, slog.LevelWarn, "could not disconnect groundwork", req.LogAttrs()...)
 		return eee
 
 	case req.Status == 503:
 		eee := fmt.Errorf("%w: %v", tcgerr.ErrSynchronizer, string(req.Response))
 		req.Err = eee
-		sdklog.Logger.LogAttrs(context.Background(), slog.LevelWarn, "could not disconnect groundwork", req.LogAttrs()...)
+		sdklog.Logger.LogAttrs(ctx, slog.LevelWarn, "could not disconnect groundwork", req.LogAttrs()...)
 		return eee
 
 	case req.Status != 200:
 		eee := fmt.Errorf("%w: %v", tcgerr.ErrUndecided, string(req.Response))
 		req.Err = eee
-		sdklog.Logger.LogAttrs(context.Background(), slog.LevelWarn, "could not disconnect groundwork", req.Details()...)
+		sdklog.Logger.LogAttrs(ctx, slog.LevelWarn, "could not disconnect groundwork", req.Details()...)
 		return eee
 	}
-	sdklog.Logger.LogAttrs(context.Background(), slog.LevelDebug, "disconnect groundwork", req.LogAttrs()...)
+	sdklog.Logger.LogAttrs(ctx, slog.LevelDebug, "disconnect groundwork", req.LogAttrs()...)
 	return nil
 }
 
@@ -330,28 +330,28 @@ func (client *GWClient) ValidateToken(appName, apiToken string) error {
 		"gwos-api-token": apiToken,
 	}
 
-	req := new(Req)
-	err := client.doReq(context.Background(), req, http.MethodPost, GWEntrypointValidateToken, "",
+	ctx, req := context.TODO(), Req{}
+	err := client.doReq(ctx, &req, http.MethodPost, GWEntrypointValidateToken, "",
 		headers, formValues, nil)
 
 	if err == nil {
 		if req.Status == 200 {
 			if b, e := strconv.ParseBool(string(req.Response)); e == nil && b {
-				sdklog.Logger.LogAttrs(context.Background(), slog.LevelDebug, "validate groundwork token", req.LogAttrs()...)
+				sdklog.Logger.LogAttrs(ctx, slog.LevelDebug, "validate groundwork token", req.LogAttrs()...)
 				return nil
 			}
 			eee := fmt.Errorf("%w: %v", tcgerr.ErrUnauthorized, "invalid gwos-app-name or gwos-api-token")
 			req.Err = eee
-			sdklog.Logger.LogAttrs(context.Background(), slog.LevelWarn, "could not validate groundwork token", req.LogAttrs()...)
+			sdklog.Logger.LogAttrs(ctx, slog.LevelWarn, "could not validate groundwork token", req.LogAttrs()...)
 			return eee
 		}
 		eee := fmt.Errorf("%w: %v", tcgerr.ErrUndecided, string(req.Response))
 		req.Err = eee
-		sdklog.Logger.LogAttrs(context.Background(), slog.LevelWarn, "could not validate groundwork token", req.Details()...)
+		sdklog.Logger.LogAttrs(ctx, slog.LevelWarn, "could not validate groundwork token", req.Details()...)
 		return eee
 	}
 
-	sdklog.Logger.LogAttrs(context.Background(), slog.LevelError, "could not validate groundwork token", req.LogAttrs()...)
+	sdklog.Logger.LogAttrs(ctx, slog.LevelError, "could not validate groundwork token", req.LogAttrs()...)
 	if tcgerr.IsErrorDNS(err) || tcgerr.IsErrorConnection(err) || tcgerr.IsErrorTimedOut(err) {
 		return fmt.Errorf("%w: %v", tcgerr.ErrTransient, err.Error())
 	}
@@ -471,14 +471,15 @@ func (client *GWClient) GetServicesByAgent(agentID string, gwServices *GWService
 	params["query"] = "agentid = '" + agentID + "'"
 	params["depth"] = "Shallow"
 
-	response, err := client.sendRequest(context.Background(), http.MethodGet, GWEntrypointServices, BuildQueryParams(params), nil)
+	ctx := context.TODO()
+	response, err := client.sendRequest(ctx, http.MethodGet, GWEntrypointServices, BuildQueryParams(params), nil)
 	if err != nil {
-		sdklog.Logger.LogAttrs(context.Background(), slog.LevelError, "could not get GW services", slog.String("error", err.Error()))
+		sdklog.Logger.LogAttrs(ctx, slog.LevelError, "could not get GW services", slog.String("error", err.Error()))
 		return err
 	}
 	err = json.Unmarshal(response, gwServices)
 	if err != nil {
-		sdklog.Logger.LogAttrs(context.Background(), slog.LevelError, "could not parse received GW services", slog.String("error", err.Error()))
+		sdklog.Logger.LogAttrs(ctx, slog.LevelError, "could not parse received GW services", slog.String("error", err.Error()))
 		return err
 	}
 	return nil
@@ -503,14 +504,15 @@ func (client *GWClient) GetHostGroupsByAppTypeAndHostNames(appType string, hostN
 	params["query"] = query
 	params["depth"] = "Shallow"
 
-	response, err := client.sendRequest(context.Background(), http.MethodGet, GWEntrypointHostgroups, BuildQueryParams(params), nil)
+	ctx := context.TODO()
+	response, err := client.sendRequest(ctx, http.MethodGet, GWEntrypointHostgroups, BuildQueryParams(params), nil)
 	if err != nil {
-		sdklog.Logger.LogAttrs(context.Background(), slog.LevelError, "could not get GW host groups", slog.String("error", err.Error()))
+		sdklog.Logger.LogAttrs(ctx, slog.LevelError, "could not get GW host groups", slog.String("error", err.Error()))
 		return err
 	}
 	err = json.Unmarshal(response, gwHostGroups)
 	if err != nil {
-		sdklog.Logger.LogAttrs(context.Background(), slog.LevelError, "could not parse received GW host groups", slog.String("error", err.Error()))
+		sdklog.Logger.LogAttrs(ctx, slog.LevelError, "could not parse received GW host groups", slog.String("error", err.Error()))
 		return err
 	}
 	return nil
@@ -530,8 +532,8 @@ func (client *GWClient) sendRequest(ctx context.Context, httpMethod string, entr
 		headers[k] = v
 	}
 
-	req := new(Req)
-	err := client.doReq(ctx, req, httpMethod, entrypoint, queryStr, headers, nil, payload)
+	req := Req{}
+	err := client.doReq(ctx, &req, httpMethod, entrypoint, queryStr, headers, nil, payload)
 	if err == nil && req.Status == 401 {
 		sdklog.Logger.LogAttrs(ctx, slog.LevelDebug, "could not send request: reconnecting")
 		if err := client.Connect(); err != nil {

--- a/sdk/mapping/mapping_test.go
+++ b/sdk/mapping/mapping_test.go
@@ -1133,12 +1133,14 @@ func testData() (tagMaps []map[string]string) {
 	}
 
 	tagMaps = make([]map[string]string, 0, len(payloads))
+	var p P
+	var m map[string]string
 	for _, payload := range payloads {
-		p := new(P)
-		if err := json.Unmarshal([]byte(payload), p); err != nil {
+		p = P{}
+		if err := json.Unmarshal([]byte(payload), &p); err != nil {
 			panic(err)
 		}
-		m := map[string]string{}
+		m = map[string]string{}
 		for _, tag := range p.Metrics[0].Tags {
 			m[tag.Key] = tag.Value
 		}

--- a/sdk/transit/inventory.go
+++ b/sdk/transit/inventory.go
@@ -167,7 +167,7 @@ func (p ResourceGroup) String() string {
 
 // InventoryRequest defines SynchronizeInventory payload
 type InventoryRequest struct {
-	Context       *TracerContext      `json:"context,omitempty"`
+	Context       TracerContext       `json:"context"`
 	OwnershipType HostOwnershipType   `json:"ownershipType,omitempty"`
 	Resources     []InventoryResource `json:"resources"`
 	Groups        []ResourceGroup     `json:"groups,omitempty"`
@@ -182,9 +182,6 @@ func (p *InventoryRequest) AddResourceGroup(gr ResourceGroup) {
 }
 
 func (p *InventoryRequest) SetContext(c TracerContext) {
-	if p.Context == nil {
-		p.Context = new(TracerContext)
-	}
 	p.Context.SetContext(c)
 }
 

--- a/sdk/transit/monitored.go
+++ b/sdk/transit/monitored.go
@@ -83,7 +83,7 @@ type MonitoredService struct {
 	BaseInfo
 	MonitoredInfo
 	// metrics
-	Metrics []TimeSeries `json:"metrics"`
+	Metrics []TimeSeries `json:"metrics,omitempty"`
 }
 
 func (p *MonitoredService) AddMetric(t TimeSeries) {

--- a/sdk/transit/monitored.go
+++ b/sdk/transit/monitored.go
@@ -33,11 +33,11 @@ func (p *MonitoredInfo) SetNextCheckTime(t *Timestamp) {
 
 // A MonitoredResource defines the current status and services of a resource during a metrics scan.
 // Examples include:
-//  * nagios host
-//  * virtual machine instance
-//  * RDS database
-//  * storage devices such as disks
-//  * cloud resources such as cloud apps, cloud functions(lambdas)
+//   - nagios host
+//   - virtual machine instance
+//   - RDS database
+//   - storage devices such as disks
+//   - cloud resources such as cloud apps, cloud functions(lambdas)
 //
 // A MonitoredResource is the representation of a specific monitored resource during a metric scan.
 // Each MonitoredResource contains list of services (MonitoredService). A MonitoredResource does not have metrics,
@@ -107,7 +107,7 @@ func (p MonitoredService) ToInventoryService() InventoryService {
 
 // ResourcesWithServicesRequest defines SendResourcesWithMetrics payload
 type ResourcesWithServicesRequest struct {
-	Context   *TracerContext      `json:"context,omitempty"`
+	Context   TracerContext       `json:"context"`
 	Resources []MonitoredResource `json:"resources"`
 	Groups    []ResourceGroup     `json:"groups,omitempty"`
 }
@@ -121,9 +121,6 @@ func (p *ResourcesWithServicesRequest) AddResourceGroup(gr ResourceGroup) {
 }
 
 func (p *ResourcesWithServicesRequest) SetContext(c TracerContext) {
-	if p.Context == nil {
-		p.Context = new(TracerContext)
-	}
 	p.Context.SetContext(c)
 }
 

--- a/services/agent.go
+++ b/services/agent.go
@@ -168,7 +168,7 @@ func (service *AgentService) DemandConfig() error {
 }
 
 // MakeTracerContext implements AgentServices.MakeTracerContext interface
-func (service *AgentService) MakeTracerContext() *transit.TracerContext {
+func (service *AgentService) MakeTracerContext() transit.TracerContext {
 	/* combine TraceToken from fixed and incremental parts */
 	tokenBuf := make([]byte, 16)
 	copy(tokenBuf, service.tracerToken)
@@ -190,7 +190,7 @@ func (service *AgentService) MakeTracerContext() *transit.TracerContext {
 		appType = traceOnDemandAppType
 	}
 
-	return &transit.TracerContext{
+	return transit.TracerContext{
 		AgentID:    agentID,
 		AppType:    appType,
 		TimeStamp:  transit.NewTimestamp(),

--- a/services/agent.go
+++ b/services/agent.go
@@ -28,6 +28,7 @@ import (
 	"github.com/patrickmn/go-cache"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/collectors"
+	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/propagation"
@@ -124,13 +125,14 @@ func GetAgentService() *AgentService {
 			agentService.hookInterrupt()
 		}
 
-		log.Debug().
-			Str("connector", fmt.Sprintf("%+v", *agentService.Connector)).
-			Str("suppress", fmt.Sprintf("%+v", config.Suppress)).
+		log.Debug().Func(func(e *zerolog.Event) {
+			e.Strs("env", os.Environ()).
+				Str("connector", fmt.Sprintf("%+v", *agentService.Connector)).
+				Str("suppress", fmt.Sprintf("%+v", config.Suppress))
+		}).
+			Stringer("httpClientTimeout", clients.HttpClient.Timeout).
+			Stringer("httpClientTimeoutGW", clients.HttpClientGW.Timeout).
 			Bool("tlsClientInsecure", clients.HttpClientTransport.TLSClientConfig.InsecureSkipVerify).
-			Str("httpClientTimeout", clients.HttpClient.Timeout.String()).
-			Str("httpClientTimeoutGW", clients.HttpClientGW.Timeout.String()).
-			Strs("env", os.Environ()).
 			Msg("starting with config")
 	})
 
@@ -410,8 +412,8 @@ func (service *AgentService) config(data []byte) error {
 		Str("AgentID", service.AgentID).
 		Str("AppType", service.AppType).
 		Str("AppName", service.AppName).
-		Str("BatchEvents", service.BatchEvents.String()).
-		Str("BatchMetrics", service.BatchMetrics.String()).
+		Stringer("BatchEvents", service.BatchEvents).
+		Stringer("BatchMetrics", service.BatchMetrics).
 		Int("BatchMaxBytes", service.BatchMaxBytes).
 		Str("ControllerAddr", service.ControllerAddr).
 		Str("DSClient", service.dsClient.HostName).

--- a/services/agent_test.go
+++ b/services/agent_test.go
@@ -27,6 +27,8 @@ func init() {
 func TestAgentService(t *testing.T) {
 	t.Cleanup(func() {
 		assert.NoError(t, os.RemoveAll(filepath.Join(GetAgentService().Connector.NatsStoreDir, "jetstream")))
+		assert.NoError(t, os.RemoveAll(filepath.Join(GetController().Connector.NatsStoreDir, "inventory.json")))
+		assert.NoError(t, os.RemoveAll(filepath.Join(GetController().Connector.NatsStoreDir, "inventory1.json")))
 		assert.NoError(t, os.Remove(GetAgentService().Connector.NatsStoreDir))
 	})
 

--- a/services/controller.go
+++ b/services/controller.go
@@ -26,6 +26,7 @@ import (
 	"github.com/patrickmn/go-cache"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
+	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
 	swaggerFiles "github.com/swaggo/files"
 	ginSwagger "github.com/swaggo/gin-swagger"
@@ -631,7 +632,7 @@ func (controller *Controller) checkAccess(c *gin.Context) {
 	/* check local pin */
 	pin := controller.Connector.ControllerPin
 	if len(pin) > 0 && pin == c.Request.Header.Get("X-PIN") {
-		log.Debug().Str("url", c.Request.URL.Redacted()).
+		log.Debug().Func(func(e *zerolog.Event) { e.Str("url", c.Request.URL.Redacted()) }).
 			Msg("access allowed with X-PIN")
 		return
 	}
@@ -655,7 +656,7 @@ func (controller *Controller) checkAccess(c *gin.Context) {
 		var err error
 		defer func() {
 			if err == nil {
-				log.Debug().Str("url", c.Request.URL.Redacted()).
+				log.Debug().Func(func(e *zerolog.Event) { e.Str("url", c.Request.URL.Redacted()) }).
 					Str("username", username).
 					Msg("access allowed with BASIC")
 				return
@@ -693,7 +694,7 @@ func (controller *Controller) checkAccess(c *gin.Context) {
 	var err error
 	defer func() {
 		if err == nil {
-			log.Debug().Str("url", c.Request.URL.Redacted()).
+			log.Debug().Func(func(e *zerolog.Event) { e.Str("url", c.Request.URL.Redacted()) }).
 				Str("gwosAppName", gwosAppName).
 				Msg("access allowed with GWOS")
 			return

--- a/services/controller_test.go
+++ b/services/controller_test.go
@@ -29,6 +29,8 @@ func init() {
 func TestController(t *testing.T) {
 	t.Cleanup(func() {
 		assert.NoError(t, os.RemoveAll(filepath.Join(GetController().Connector.NatsStoreDir, "jetstream")))
+		assert.NoError(t, os.RemoveAll(filepath.Join(GetController().Connector.NatsStoreDir, "inventory.json")))
+		assert.NoError(t, os.RemoveAll(filepath.Join(GetController().Connector.NatsStoreDir, "inventory1.json")))
 		assert.NoError(t, os.Remove(GetController().Connector.NatsStoreDir))
 	})
 

--- a/services/nats.go
+++ b/services/nats.go
@@ -41,8 +41,8 @@ func Put2Nats(ctx context.Context, subj string, payload []byte) error {
 
 	if len(payload) > int(agentService.NatsMaxPayload) {
 		n0 := len(payload)
-		buf := new(bytes.Buffer)
-		_, err = clients.GZip(ctx, buf, payload)
+		var buf bytes.Buffer
+		_, err = clients.GZip(ctx, &buf, payload)
 		if err != nil {
 			return err
 		}

--- a/services/transit.go
+++ b/services/transit.go
@@ -415,6 +415,7 @@ func (service *TransitService) Sync(ctx context.Context, p *transit.InventoryReq
 	}
 
 	if len(mon.Resources) > 0 {
+		mon.SetContext(service.MakeTracerContext())
 		payload, err = json.Marshal(mon)
 		if err != nil {
 			return err

--- a/services/transit.go
+++ b/services/transit.go
@@ -2,10 +2,12 @@ package services
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"os"
 	"path/filepath"
+	"strconv"
 	"sync"
 	"time"
 
@@ -14,6 +16,7 @@ import (
 	"github.com/gwos/tcg/batcher/metrics"
 	"github.com/gwos/tcg/config"
 	"github.com/gwos/tcg/sdk/clients"
+	"github.com/gwos/tcg/sdk/transit"
 	"github.com/gwos/tcg/tracing"
 	"github.com/rs/zerolog/log"
 )
@@ -365,4 +368,172 @@ func (service *TransitService) SynchronizeInventory(ctx context.Context, payload
 	ctx = clients.CtxWithHeader(ctx, header)
 	err = Put2Nats(ctx, subjInventoryMetrics, payload)
 	return err
+}
+
+// SynchronizeInventoryExt processes extended inventory included additional properties
+func (service *TransitService) SynchronizeInventoryExt(ctx context.Context, payload []byte) error {
+	var p transit.InventoryRequest
+	if err := json.Unmarshal(payload, &p); err != nil {
+		return err
+	}
+	return service.Sync(ctx, &p)
+}
+
+// Sync processes inventory
+func (service *TransitService) Sync(ctx context.Context, p *transit.InventoryRequest) error {
+	_, span := tracing.StartTraceSpan(ctx, "services", string(TOpSyncInventory))
+	var err error
+	defer func() {
+		tracing.EndTraceSpan(span,
+			tracing.TraceAttrError(err),
+		)
+		if err != nil {
+			log.Err(err).Msg("Sync failed")
+		}
+	}()
+
+	if v, err := strconv.ParseBool(os.Getenv("TCG_INVENTORY_EXT")); err != nil || !v {
+		payload, err := json.Marshal(p)
+		if err != nil {
+			return err
+		}
+		return service.SynchronizeInventory(ctx, payload)
+	}
+	log.Info().Msg("Sync: TCG_INVENTORY_EXT")
+
+	var dt transit.Downtimes
+	var mon transit.ResourcesWithServicesRequest
+	filterExtInfo(p, &mon, &dt)
+
+	payload, err := json.Marshal(p)
+	if err != nil {
+		return err
+	}
+	err = service.SynchronizeInventory(ctx, payload)
+	if err != nil {
+		return err
+	}
+
+	if len(mon.Resources) > 0 {
+		payload, err = json.Marshal(mon)
+		if err != nil {
+			return err
+		}
+		err = service.SendResourceWithMetrics(ctx, payload)
+		if err != nil {
+			return err
+		}
+	}
+
+	if len(dt.BizHostServiceInDowntimes) > 0 {
+		payload, err = json.Marshal(dt)
+		if err != nil {
+			return err
+		}
+		// TODO: Sync Downtimes
+		log.Trace().RawJSON("downtimes", payload).Msg("TODO: Sync Downtimes")
+	}
+
+	return nil
+}
+
+func filterExtInfo(
+	p *transit.InventoryRequest,
+	mon *transit.ResourcesWithServicesRequest,
+	dt *transit.Downtimes,
+) {
+	var iPropsRes map[string]int = map[string]int{"Alias": 0, "Notes": 0}
+	var iPropsSvc map[string]int = map[string]int{"Notes": 0}
+
+	var mRes transit.MonitoredResource
+	var mSvc transit.MonitoredService
+
+	for i, iRes := range p.Resources {
+		mRes = transit.MonitoredResource{}
+		mRes.BaseResource = iRes.BaseResource
+		mRes.Properties = iRes.Properties
+
+		iProps := make(map[string]transit.TypedValue, len(iPropsRes))
+		for k := range iPropsRes {
+			if v, ok := iRes.Properties[k]; ok {
+				iProps[k] = v
+			}
+		}
+		p.Resources[i].Properties = iProps
+
+		if v, ok := mRes.Properties["MonitorStatus"]; ok {
+			delete(mRes.Properties, "MonitorStatus")
+			mRes.SetStatus(transit.MonitorStatus(*v.StringValue))
+		}
+		if v, ok := mRes.Properties["LastPluginOutput"]; ok {
+			delete(mRes.Properties, "LastPluginOutput")
+			mRes.SetLastPluginOutput(*v.StringValue)
+		}
+		if v, ok := mRes.Properties["LastCheckTime"]; ok {
+			delete(mRes.Properties, "LastCheckTime")
+			mRes.SetLastCheckTime(v.TimeValue)
+		} else {
+			mRes.SetLastCheckTime(transit.NewTimestamp())
+		}
+		if v, ok := mRes.Properties["NextCheckTime"]; ok {
+			delete(mRes.Properties, "NextCheckTime")
+			mRes.SetNextCheckTime(v.TimeValue)
+		}
+		if v, ok := mRes.Properties["ScheduledDowntimeDepth"]; ok {
+			delete(mRes.Properties, "ScheduledDowntimeDepth")
+			dt.BizHostServiceInDowntimes = append(dt.BizHostServiceInDowntimes, transit.Downtime{
+				EntityType:             "HOST",
+				EntityName:             mRes.Name,
+				HostName:               mRes.Name,
+				ScheduledDowntimeDepth: int(*v.IntegerValue),
+			})
+		}
+
+		for j, iSvc := range iRes.Services {
+			mSvc = transit.MonitoredService{}
+			mSvc.BaseInfo = iSvc.BaseInfo
+			mSvc.Properties = iSvc.Properties
+
+			iProps := make(map[string]transit.TypedValue, len(iPropsSvc))
+			for k := range iPropsSvc {
+				if v, ok := iSvc.Properties[k]; ok {
+					iProps[k] = v
+				}
+			}
+			p.Resources[i].Services[j].Properties = iProps
+
+			if v, ok := mSvc.Properties["MonitorStatus"]; ok {
+				delete(mSvc.Properties, "MonitorStatus")
+				mSvc.SetStatus(transit.MonitorStatus(*v.StringValue))
+			}
+			if v, ok := mSvc.Properties["LastPluginOutput"]; ok {
+				delete(mSvc.Properties, "LastPluginOutput")
+				mSvc.SetLastPluginOutput(*v.StringValue)
+			}
+			if v, ok := mSvc.Properties["LastCheckTime"]; ok {
+				delete(mSvc.Properties, "LastCheckTime")
+				mSvc.SetLastCheckTime(v.TimeValue)
+			} else {
+				mSvc.SetLastCheckTime(transit.NewTimestamp())
+			}
+			if v, ok := mSvc.Properties["NextCheckTime"]; ok {
+				delete(mSvc.Properties, "NextCheckTime")
+				mSvc.SetNextCheckTime(v.TimeValue)
+			}
+			if v, ok := mSvc.Properties["ScheduledDowntimeDepth"]; ok {
+				delete(mSvc.Properties, "ScheduledDowntimeDepth")
+				dt.BizHostServiceInDowntimes = append(dt.BizHostServiceInDowntimes, transit.Downtime{
+					EntityType:             "HOST",
+					EntityName:             mRes.Name,
+					HostName:               mRes.Name,
+					ServiceDescription:     mSvc.Description,
+					ScheduledDowntimeDepth: int(*v.IntegerValue),
+				})
+			}
+
+			mRes.AddService(mSvc)
+		}
+
+		mon.AddResource(mRes)
+	}
 }

--- a/services/transit_test.go
+++ b/services/transit_test.go
@@ -1,0 +1,376 @@
+package services
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/gwos/tcg/sdk/transit"
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_SyncExt(t *testing.T) {
+	jsonInventoryExt := `{
+        "groups": [
+            {
+                "groupName": "atest-hst",
+                "resources": [
+                    { "name": "atest22", "type": "host" },
+                    { "name": "atest11", "type": "host" }
+                ],
+                "type": "HostGroup"
+            },
+            {
+                "groupName": "atest-svc",
+                "resources": [
+                    { "name": "icmp_ping_alive", "owner": "atest22", "type": "service" },
+                    { "name": "icmp_ping_alive", "owner": "atest11", "type": "service" }
+                ],
+                "type": "ServiceGroup"
+            }
+        ],
+        "resources": [
+            {
+                "description": "atest11",
+                "device": "127.1.1.11",
+                "name": "atest11",
+                "properties": {
+                    "Alias": { "stringValue": "atest11", "valueType": "StringType" },
+                    "CheckType": { "stringValue": "ACTIVE", "valueType": "StringType" },
+                    "CurrentAttempt": { "integerValue": 1, "valueType": "IntegerType" },
+                    "CurrentNotificationNumber": { "integerValue": 0, "valueType": "IntegerType" },
+                    "ExecutionTime": { "doubleValue": 0.003, "valueType": "DoubleType" },
+                    "LastCheckTime": { "timeValue": "1748333287000", "valueType": "TimeType" },
+                    "LastNotificationTime": { "timeValue": "0", "valueType": "TimeType" },
+                    "LastPluginOutput": {
+                        "stringValue": "OK - 127.1.1.11 rta 0.044ms lost 0%",
+                        "valueType": "StringType"
+                    },
+                    "LastStateChange": { "timeValue": "1747683022000", "valueType": "TimeType" },
+                    "Latency": { "doubleValue": 0, "valueType": "DoubleType" },
+                    "MaxAttempts": { "integerValue": 3, "valueType": "IntegerType" },
+                    "MonitorStatus": { "stringValue": "HOST_UP", "valueType": "StringType" },
+                    "NextCheckTime": { "timeValue": "1748333347000", "valueType": "TimeType" },
+                    "PercentStateChange": { "doubleValue": 0, "valueType": "DoubleType" },
+                    "PerformanceData": {
+                        "stringValue": "rta=0.044ms;3000.000;5000.000;0; pl=0%;80;100;0;100 rtmax=0.044ms;;;; rtmin=0.044ms;;;;",
+                        "valueType": "StringType"
+                    },
+                    "ScheduledDowntimeDepth": { "integerValue": 0, "valueType": "IntegerType" },
+                    "StateType": { "stringValue": "HARD", "valueType": "StringType" },
+                    "isAcknowledged": { "boolValue": false, "valueType": "BooleanType" },
+                    "isChecksEnabled": { "boolValue": true, "valueType": "BooleanType" },
+                    "isEventHandlersEnabled": { "boolValue": true, "valueType": "BooleanType" },
+                    "isFlapDetectionEnabled": { "boolValue": true, "valueType": "BooleanType" },
+                    "isNotificationsEnabled": { "boolValue": true, "valueType": "BooleanType" },
+                    "isPassiveChecksEnabled": { "boolValue": true, "valueType": "BooleanType" }
+                },
+                "services": [
+                    {
+                        "name": "icmp_ping_alive",
+                        "properties": {
+                            "CheckType": { "stringValue": "ACTIVE", "valueType": "StringType" },
+                            "CurrentAttempt": { "integerValue": 1, "valueType": "IntegerType" },
+                            "CurrentNotificationNumber": { "integerValue": 0, "valueType": "IntegerType" },
+                            "ExecutionTime": { "doubleValue": 0.004, "valueType": "DoubleType" },
+                            "LastCheckTime": { "timeValue": "1748333287000", "valueType": "TimeType" },
+                            "LastNotificationTime": { "timeValue": "0", "valueType": "TimeType" },
+                            "LastPluginOutput": {
+                                "stringValue": "OK - 127.1.1.11 rta 0.030ms lost 0%",
+                                "valueType": "StringType"
+                            },
+                            "Latency": { "doubleValue": 0, "valueType": "DoubleType" },
+                            "MaxAttempts": { "integerValue": 3, "valueType": "IntegerType" },
+                            "MonitorStatus": { "stringValue": "SERVICE_OK", "valueType": "StringType" },
+                            "NextCheckTime": { "timeValue": "1748333347000", "valueType": "TimeType" },
+                            "PercentStateChange": { "doubleValue": 0, "valueType": "DoubleType" },
+                            "PerformanceData": {
+                                "stringValue": "rta=0.030ms;3000.000;5000.000;0; pl=0%;80;100;0;100 rtmax=0.030ms;;;; rtmin=0.030ms;;;;",
+                                "valueType": "StringType"
+                            },
+                            "ScheduledDowntimeDepth": { "integerValue": 0, "valueType": "IntegerType" },
+                            "StateType": { "stringValue": "HARD", "valueType": "StringType" },
+                            "isAcceptPassiveChecks": { "boolValue": true, "valueType": "BooleanType" },
+                            "isChecksEnabled": { "boolValue": true, "valueType": "BooleanType" },
+                            "isEventHandlersEnabled": { "boolValue": true, "valueType": "BooleanType" },
+                            "isFlapDetectionEnabled": { "boolValue": true, "valueType": "BooleanType" },
+                            "isNotificationsEnabled": { "boolValue": true, "valueType": "BooleanType" },
+                            "isProblemAcknowledged": { "boolValue": false, "valueType": "BooleanType" }
+                        },
+                        "type": "service"
+                    }
+                ],
+                "type": "host"
+            },
+            {
+                "description": "atest22",
+                "device": "127.1.1.22",
+                "name": "atest22",
+                "properties": {
+                    "Alias": { "stringValue": "atest22", "valueType": "StringType" },
+                    "CheckType": { "stringValue": "ACTIVE", "valueType": "StringType" },
+                    "CurrentAttempt": { "integerValue": 1, "valueType": "IntegerType" },
+                    "CurrentNotificationNumber": { "integerValue": 0, "valueType": "IntegerType" },
+                    "ExecutionTime": { "doubleValue": 0.003, "valueType": "DoubleType" },
+                    "LastCheckTime": { "timeValue": "1748333257000", "valueType": "TimeType" },
+                    "LastNotificationTime": { "timeValue": "0", "valueType": "TimeType" },
+                    "LastPluginOutput": {
+                        "stringValue": "OK - 127.1.1.22 rta 0.048ms lost 0%",
+                        "valueType": "StringType"
+                    },
+                    "LastStateChange": { "timeValue": "1747683049000", "valueType": "TimeType" },
+                    "Latency": { "doubleValue": 0.001, "valueType": "DoubleType" },
+                    "MaxAttempts": { "integerValue": 3, "valueType": "IntegerType" },
+                    "MonitorStatus": { "stringValue": "HOST_UP", "valueType": "StringType" },
+                    "NextCheckTime": { "timeValue": "1748333317000", "valueType": "TimeType" },
+                    "PercentStateChange": { "doubleValue": 0, "valueType": "DoubleType" },
+                    "PerformanceData": {
+                        "stringValue": "rta=0.048ms;3000.000;5000.000;0; pl=0%;80;100;0;100 rtmax=0.048ms;;;; rtmin=0.048ms;;;;",
+                        "valueType": "StringType"
+                    },
+                    "ScheduledDowntimeDepth": { "integerValue": 0, "valueType": "IntegerType" },
+                    "StateType": { "stringValue": "HARD", "valueType": "StringType" },
+                    "isAcknowledged": { "boolValue": false, "valueType": "BooleanType" },
+                    "isChecksEnabled": { "boolValue": true, "valueType": "BooleanType" },
+                    "isEventHandlersEnabled": { "boolValue": true, "valueType": "BooleanType" },
+                    "isFlapDetectionEnabled": { "boolValue": true, "valueType": "BooleanType" },
+                    "isNotificationsEnabled": { "boolValue": true, "valueType": "BooleanType" },
+                    "isPassiveChecksEnabled": { "boolValue": true, "valueType": "BooleanType" }
+                },
+                "services": [
+                    {
+                        "name": "icmp_ping_alive",
+                        "properties": {
+                            "CheckType": { "stringValue": "ACTIVE", "valueType": "StringType" },
+                            "CurrentAttempt": { "integerValue": 1, "valueType": "IntegerType" },
+                            "CurrentNotificationNumber": { "integerValue": 0, "valueType": "IntegerType" },
+                            "ExecutionTime": { "doubleValue": 0.004, "valueType": "DoubleType" },
+                            "LastCheckTime": { "timeValue": "1748333259000", "valueType": "TimeType" },
+                            "LastNotificationTime": { "timeValue": "0", "valueType": "TimeType" },
+                            "LastPluginOutput": {
+                                "stringValue": "OK - 127.1.1.22 rta 0.033ms lost 0%",
+                                "valueType": "StringType"
+                            },
+                            "Latency": { "doubleValue": 0, "valueType": "DoubleType" },
+                            "MaxAttempts": { "integerValue": 3, "valueType": "IntegerType" },
+                            "MonitorStatus": { "stringValue": "SERVICE_OK", "valueType": "StringType" },
+                            "NextCheckTime": { "timeValue": "1748333319000", "valueType": "TimeType" },
+                            "PercentStateChange": { "doubleValue": 0, "valueType": "DoubleType" },
+                            "PerformanceData": {
+                                "stringValue": "rta=0.033ms;3000.000;5000.000;0; pl=0%;80;100;0;100 rtmax=0.033ms;;;; rtmin=0.033ms;;;;",
+                                "valueType": "StringType"
+                            },
+                            "ScheduledDowntimeDepth": { "integerValue": 0, "valueType": "IntegerType" },
+                            "StateType": { "stringValue": "HARD", "valueType": "StringType" },
+                            "isAcceptPassiveChecks": { "boolValue": true, "valueType": "BooleanType" },
+                            "isChecksEnabled": { "boolValue": true, "valueType": "BooleanType" },
+                            "isEventHandlersEnabled": { "boolValue": true, "valueType": "BooleanType" },
+                            "isFlapDetectionEnabled": { "boolValue": true, "valueType": "BooleanType" },
+                            "isNotificationsEnabled": { "boolValue": true, "valueType": "BooleanType" },
+                            "isProblemAcknowledged": { "boolValue": false, "valueType": "BooleanType" }
+                        },
+                        "type": "service"
+                    }
+                ],
+                "type": "host"
+            }
+        ]
+    }`
+
+	jsonInventory := `{
+        "groups": [
+            {
+                "groupName": "atest-hst",
+                "resources": [
+                    { "name": "atest22", "type": "host" },
+                    { "name": "atest11", "type": "host" }
+                ],
+                "type": "HostGroup"
+            },
+            {
+                "groupName": "atest-svc",
+                "resources": [
+                    { "name": "icmp_ping_alive", "owner": "atest22", "type": "service" },
+                    { "name": "icmp_ping_alive", "owner": "atest11", "type": "service" }
+                ],
+                "type": "ServiceGroup"
+            }
+        ],
+        "resources": [
+            {
+                "description": "atest11",
+                "device": "127.1.1.11",
+                "name": "atest11",
+                "properties": { "Alias": { "stringValue": "atest11", "valueType": "StringType" } },
+                "services": [{ "name": "icmp_ping_alive", "type": "service" }],
+                "type": "host"
+            },
+            {
+                "description": "atest22",
+                "device": "127.1.1.22",
+                "name": "atest22",
+                "properties": { "Alias": { "stringValue": "atest22", "valueType": "StringType" } },
+                "services": [{ "name": "icmp_ping_alive", "type": "service" }],
+                "type": "host"
+            }
+        ]
+    }`
+
+	jsonMonitoring := `{
+        "resources": [
+            {
+                "description": "atest11",
+                "device": "127.1.1.11",
+                "lastCheckTime": "1748333287000",
+                "lastPluginOutput": "OK - 127.1.1.11 rta 0.044ms lost 0%",
+                "name": "atest11",
+                "nextCheckTime": "1748333347000",
+                "properties": {
+                    "Alias": { "stringValue": "atest11", "valueType": "StringType" },
+                    "CheckType": { "stringValue": "ACTIVE", "valueType": "StringType" },
+                    "CurrentAttempt": { "integerValue": 1, "valueType": "IntegerType" },
+                    "CurrentNotificationNumber": { "integerValue": 0, "valueType": "IntegerType" },
+                    "ExecutionTime": { "doubleValue": 0.003, "valueType": "DoubleType" },
+                    "LastNotificationTime": { "timeValue": "0", "valueType": "TimeType" },
+                    "LastStateChange": { "timeValue": "1747683022000", "valueType": "TimeType" },
+                    "Latency": { "doubleValue": 0, "valueType": "DoubleType" },
+                    "MaxAttempts": { "integerValue": 3, "valueType": "IntegerType" },
+                    "PercentStateChange": { "doubleValue": 0, "valueType": "DoubleType" },
+                    "PerformanceData": {
+                        "stringValue": "rta=0.044ms;3000.000;5000.000;0; pl=0%;80;100;0;100 rtmax=0.044ms;;;; rtmin=0.044ms;;;;",
+                        "valueType": "StringType"
+                    },
+                    "StateType": { "stringValue": "HARD", "valueType": "StringType" },
+                    "isAcknowledged": { "boolValue": false, "valueType": "BooleanType" },
+                    "isChecksEnabled": { "boolValue": true, "valueType": "BooleanType" },
+                    "isEventHandlersEnabled": { "boolValue": true, "valueType": "BooleanType" },
+                    "isFlapDetectionEnabled": { "boolValue": true, "valueType": "BooleanType" },
+                    "isNotificationsEnabled": { "boolValue": true, "valueType": "BooleanType" },
+                    "isPassiveChecksEnabled": { "boolValue": true, "valueType": "BooleanType" }
+                },
+                "services": [
+                    {
+                        "lastCheckTime": "1748333287000",
+                        "lastPluginOutput": "OK - 127.1.1.11 rta 0.030ms lost 0%",
+                        "name": "icmp_ping_alive",
+                        "nextCheckTime": "1748333347000",
+                        "properties": {
+                            "CheckType": { "stringValue": "ACTIVE", "valueType": "StringType" },
+                            "CurrentAttempt": { "integerValue": 1, "valueType": "IntegerType" },
+                            "CurrentNotificationNumber": { "integerValue": 0, "valueType": "IntegerType" },
+                            "ExecutionTime": { "doubleValue": 0.004, "valueType": "DoubleType" },
+                            "LastNotificationTime": { "timeValue": "0", "valueType": "TimeType" },
+                            "Latency": { "doubleValue": 0, "valueType": "DoubleType" },
+                            "MaxAttempts": { "integerValue": 3, "valueType": "IntegerType" },
+                            "PercentStateChange": { "doubleValue": 0, "valueType": "DoubleType" },
+                            "PerformanceData": {
+                                "stringValue": "rta=0.030ms;3000.000;5000.000;0; pl=0%;80;100;0;100 rtmax=0.030ms;;;; rtmin=0.030ms;;;;",
+                                "valueType": "StringType"
+                            },
+                            "StateType": { "stringValue": "HARD", "valueType": "StringType" },
+                            "isAcceptPassiveChecks": { "boolValue": true, "valueType": "BooleanType" },
+                            "isChecksEnabled": { "boolValue": true, "valueType": "BooleanType" },
+                            "isEventHandlersEnabled": { "boolValue": true, "valueType": "BooleanType" },
+                            "isFlapDetectionEnabled": { "boolValue": true, "valueType": "BooleanType" },
+                            "isNotificationsEnabled": { "boolValue": true, "valueType": "BooleanType" },
+                            "isProblemAcknowledged": { "boolValue": false, "valueType": "BooleanType" }
+                        },
+                        "status": "SERVICE_OK",
+                        "type": "service"
+                    }
+                ],
+                "status": "HOST_UP",
+                "type": "host"
+            },
+            {
+                "description": "atest22",
+                "device": "127.1.1.22",
+                "lastCheckTime": "1748333257000",
+                "lastPluginOutput": "OK - 127.1.1.22 rta 0.048ms lost 0%",
+                "name": "atest22",
+                "nextCheckTime": "1748333317000",
+                "properties": {
+                    "Alias": { "stringValue": "atest22", "valueType": "StringType" },
+                    "CheckType": { "stringValue": "ACTIVE", "valueType": "StringType" },
+                    "CurrentAttempt": { "integerValue": 1, "valueType": "IntegerType" },
+                    "CurrentNotificationNumber": { "integerValue": 0, "valueType": "IntegerType" },
+                    "ExecutionTime": { "doubleValue": 0.003, "valueType": "DoubleType" },
+                    "LastNotificationTime": { "timeValue": "0", "valueType": "TimeType" },
+                    "LastStateChange": { "timeValue": "1747683049000", "valueType": "TimeType" },
+                    "Latency": { "doubleValue": 0.001, "valueType": "DoubleType" },
+                    "MaxAttempts": { "integerValue": 3, "valueType": "IntegerType" },
+                    "PercentStateChange": { "doubleValue": 0, "valueType": "DoubleType" },
+                    "PerformanceData": {
+                        "stringValue": "rta=0.048ms;3000.000;5000.000;0; pl=0%;80;100;0;100 rtmax=0.048ms;;;; rtmin=0.048ms;;;;",
+                        "valueType": "StringType"
+                    },
+                    "StateType": { "stringValue": "HARD", "valueType": "StringType" },
+                    "isAcknowledged": { "boolValue": false, "valueType": "BooleanType" },
+                    "isChecksEnabled": { "boolValue": true, "valueType": "BooleanType" },
+                    "isEventHandlersEnabled": { "boolValue": true, "valueType": "BooleanType" },
+                    "isFlapDetectionEnabled": { "boolValue": true, "valueType": "BooleanType" },
+                    "isNotificationsEnabled": { "boolValue": true, "valueType": "BooleanType" },
+                    "isPassiveChecksEnabled": { "boolValue": true, "valueType": "BooleanType" }
+                },
+                "services": [
+                    {
+                        "lastCheckTime": "1748333259000",
+                        "lastPluginOutput": "OK - 127.1.1.22 rta 0.033ms lost 0%",
+                        "name": "icmp_ping_alive",
+                        "nextCheckTime": "1748333319000",
+                        "properties": {
+                            "CheckType": { "stringValue": "ACTIVE", "valueType": "StringType" },
+                            "CurrentAttempt": { "integerValue": 1, "valueType": "IntegerType" },
+                            "CurrentNotificationNumber": { "integerValue": 0, "valueType": "IntegerType" },
+                            "ExecutionTime": { "doubleValue": 0.004, "valueType": "DoubleType" },
+                            "LastNotificationTime": { "timeValue": "0", "valueType": "TimeType" },
+                            "Latency": { "doubleValue": 0, "valueType": "DoubleType" },
+                            "MaxAttempts": { "integerValue": 3, "valueType": "IntegerType" },
+                            "PercentStateChange": { "doubleValue": 0, "valueType": "DoubleType" },
+                            "PerformanceData": {
+                                "stringValue": "rta=0.033ms;3000.000;5000.000;0; pl=0%;80;100;0;100 rtmax=0.033ms;;;; rtmin=0.033ms;;;;",
+                                "valueType": "StringType"
+                            },
+                            "StateType": { "stringValue": "HARD", "valueType": "StringType" },
+                            "isAcceptPassiveChecks": { "boolValue": true, "valueType": "BooleanType" },
+                            "isChecksEnabled": { "boolValue": true, "valueType": "BooleanType" },
+                            "isEventHandlersEnabled": { "boolValue": true, "valueType": "BooleanType" },
+                            "isFlapDetectionEnabled": { "boolValue": true, "valueType": "BooleanType" },
+                            "isNotificationsEnabled": { "boolValue": true, "valueType": "BooleanType" },
+                            "isProblemAcknowledged": { "boolValue": false, "valueType": "BooleanType" }
+                        },
+                        "status": "SERVICE_OK",
+                        "type": "service"
+                    }
+                ],
+                "status": "HOST_UP",
+                "type": "host"
+            }
+        ]
+    }`
+
+	t.Run("filterExtInfo", func(t *testing.T) {
+		var inv struct {
+			transit.InventoryRequest
+			Context []byte `json:"context,omitempty"`
+		}
+		var mon struct {
+			transit.ResourcesWithServicesRequest
+			Context []byte `json:"context,omitempty"`
+		}
+		var dt struct {
+			transit.Downtimes
+			Context []byte `json:"context,omitempty"`
+		}
+		assert.NoError(t, json.Unmarshal([]byte(jsonInventoryExt), &inv))
+
+		filterExtInfo(&inv.InventoryRequest, &mon.ResourcesWithServicesRequest, &dt.Downtimes)
+
+		payload, err := json.Marshal(inv)
+		assert.NoError(t, err)
+		assert.JSONEq(t, jsonInventory, string(payload))
+
+		payload, err = json.Marshal(mon)
+		assert.NoError(t, err)
+		assert.JSONEq(t, jsonMonitoring, string(payload))
+	})
+}


### PR DESCRIPTION
For today statuses of Nagios hosts/services in Foundation updated only when monitoring info submitted.
It may lead to case when in Status Dashboard data is differ from Nagios UI.

New functions and libtransit exports added:
    TransitService.SyncExt
    TransitService.SynchronizeInventoryExt
    libtransit.SyncExt
    libtransit.SynchronizeInventoryExt

These functions handle additional properties in host/service definition. Extended inventory processed into common inventory and monitored info. Then both payloads delivered to Foundation with proper API calls.
Detailed test on processing additional properties provided.

Also, some additional changes done on testing the integration with Datageyser.

There are environment vars to turn off new functionality (for `nagios` container):
      DG_INVENTORY_V1: 1
      DG_INVENTORY_NOEXT: 1
      TCG_INVENTORY_NOEXT: true
