### PR TITLE
GROUNDWORK-5719: gzip large payloads before hitting Foundation's entity-size limit

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -279,7 +279,7 @@ func defaults() Config {
 				NatsAckWait:            time.Second * 30,
 				NatsMaxInflight:        4,
 				NatsMaxPubAcksInflight: 4,
-				NatsMaxPayload:         1024 * 1024 * 8, // 8MB github.com/nats-io/nats-server/releases/tag/v2.3.4
+				NatsMaxPayload:         1024 * 1024 * 2, // 2MB, matches Undertow's default MAX_ENTITY_SIZE on the Foundation side
 				NatsMonitorPort:        0,
 				NatsStoreDir:           "natsstore",
 				NatsStoreType:          "FILE",

--- a/sdk/clients/gwClient.go
+++ b/sdk/clients/gwClient.go
@@ -395,24 +395,44 @@ func (client *GWClient) ValidateToken(appName, apiToken string) error {
 	return err
 }
 
-// SynchronizeInventory calls API
-func (client *GWClient) SynchronizeInventory(ctx context.Context, payload []byte) ([]byte, error) {
+// httpEncodeMinSize is the payload size above which the request body is gzip-compressed
+// even when the connection isn't configured for it (HTTPEncode=false).
+// This protects direct SDK callers (e.g. the Telegraf output plugin)
+// that never go through Put2Nats's own size-triggered compression,
+// and generally reduces the odds of exceeding Foundation's entity-size limit.
+// Matches Undertow's default MAX_ENTITY_SIZE on the Foundation side.
+const httpEncodeMinSize = 2 * 1024 * 1024
+
+// resolveEncoding gzip-compresses payload when required -
+// either because HTTPEncode is enabled for the connection,
+// the payload is already gzipped, or payload exceeds httpEncodeMinSize -
+// and returns the (possibly compressed) payload along with the headers needed to declare it.
+func (client *GWClient) resolveEncoding(ctx context.Context, payload []byte) (context.Context, []byte, []string, error) {
 	headers := []string{}
 	encoding := ""
 	if IsGZipped(payload) {
 		encoding = "gzip"
 	}
-	if client.GWConnection.HTTPEncode && encoding == "" {
+	if encoding == "" && (client.GWConnection.HTTPEncode || len(payload) > httpEncodeMinSize) {
 		var buf bytes.Buffer
 		var err error
 		if ctx, err = GZip(ctx, &buf, payload); err != nil {
-			return nil, err
+			return ctx, nil, nil, err
 		}
 		payload = buf.Bytes()
 		encoding = "gzip"
 	}
 	if encoding != "" {
 		headers = append(headers, "Content-Encoding", encoding)
+	}
+	return ctx, payload, headers, nil
+}
+
+// SynchronizeInventory calls API
+func (client *GWClient) SynchronizeInventory(ctx context.Context, payload []byte) ([]byte, error) {
+	ctx, payload, headers, err := client.resolveEncoding(ctx, payload)
+	if err != nil {
+		return nil, err
 	}
 	if client.PrefixResourceNames && client.ResourceNamePrefix != "" {
 		headers = append(headers, "HostNamePrefix", client.ResourceNamePrefix)
@@ -425,22 +445,9 @@ func (client *GWClient) SynchronizeInventory(ctx context.Context, payload []byte
 
 // SendResourcesWithMetrics calls API
 func (client *GWClient) SendResourcesWithMetrics(ctx context.Context, payload []byte) ([]byte, error) {
-	headers := []string{}
-	encoding := ""
-	if IsGZipped(payload) {
-		encoding = "gzip"
-	}
-	if client.GWConnection.HTTPEncode && encoding == "" {
-		var buf bytes.Buffer
-		var err error
-		if ctx, err = GZip(ctx, &buf, payload); err != nil {
-			return nil, err
-		}
-		payload = buf.Bytes()
-		encoding = "gzip"
-	}
-	if encoding != "" {
-		headers = append(headers, "Content-Encoding", encoding)
+	ctx, payload, headers, err := client.resolveEncoding(ctx, payload)
+	if err != nil {
+		return nil, err
 	}
 	if client.PrefixResourceNames && client.ResourceNamePrefix != "" {
 		headers = append(headers, "HostNamePrefix", client.ResourceNamePrefix)

--- a/sdk/errors/errors.go
+++ b/sdk/errors/errors.go
@@ -61,7 +61,16 @@ func IsErrorAddressInUse(err error) bool {
 func IsErrorConnection(err error) bool {
 	return IsErrorConnectionAborted(err) ||
 		IsErrorConnectionRefused(err) ||
-		IsErrorConnectionReset(err)
+		IsErrorConnectionReset(err) ||
+		IsErrorBrokenPipe(err)
+}
+
+// IsErrorBrokenPipe verifies error
+// EPIPE (write on a connection the peer already closed) has no distinct WinSock
+// equivalent - Windows reports that case via WSAECONNRESET or WSAECONNABORTED instead,
+// both already covered above - so this check is only meaningful on non-Windows platforms.
+func IsErrorBrokenPipe(err error) bool {
+	return errors.Is(err, syscall.EPIPE)
 }
 
 // IsErrorConnectionAborted verifies error


### PR DESCRIPTION
Foundation's Undertow default MAX_ENTITY_SIZE is 2MB (now raised to 25MB, GROUNDWORK-5719 groundwork#537), but a standalone/parent GW connection only gzips its HTTP body when HTTPEncode is explicitly enabled - off by default outside "child" connections - so an inventory sync between 2MB and NatsMaxPayload (8MB) went out uncompressed and hit a bare HTTP 400 from Undertow before ever reaching RESTEasy.

- Lower NatsMaxPayload's default from 8MB to 2MB so Put2Nats's existing size-triggered gzip protects the NATS-dispatched connector path.
- Add a size-triggered gzip fallback (httpEncodeMinSize, 2MB) directly in GWClient's shared encoding path for direct SDK callers (e.g. the Telegraf output plugin) that never go through Put2Nats/NATS at all.
- Classify EPIPE (broken pipe) as a transient error alongside ECONNRESET/ECONNABORTED, so a mid-write connection drop is retried instead of silently dropped as permanent.