### PR TITLE
GROUNDWORK-5741 don't force DSConnection.HostName on a PMC connector before it has real config

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -234,6 +234,20 @@ func (c *GWConnection) UnmarshalYAML(unmarshal func(any) error) error {
 // GWConnections defines a set of configurations
 type GWConnections []GWConnection
 
+// HasEnabled reports whether at least one connection is enabled.
+// defaults() pre-populates GWConnections with empty placeholder entries
+// (for indexed env-var binding), so a plain length check is not a reliable
+// "has this connector received a real config yet" signal - this mirrors
+// the same Enabled filter startTransport() uses to populate gwClients.
+func (cc GWConnections) HasEnabled() bool {
+	for i := range cc {
+		if cc[i].Enabled {
+			return true
+		}
+	}
+	return false
+}
+
 // UnmarshalYAML implements the yaml.Unmarshaler interface.
 // Applies decode to items in collection for setting only fields present in yaml.
 // Note (as for gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b):
@@ -344,7 +358,12 @@ func GetConfig() *Config {
 		/* process PMC */
 		if cfg.IsPMC() {
 			cfg.Connector.InstallationMode = InstallationModePMC
-			cfg.DSConnection.HostName = os.Getenv(ParentInstanceNameEnv)
+			/* don't fake a DSConnection.HostName before any real config exists:
+			   checkAccess's bootstrap bypass relies on it staying empty until the connector
+			   has actually received a config, same as every other installation mode. */
+			if cfg.GWConnections.HasEnabled() {
+				cfg.DSConnection.HostName = os.Getenv(ParentInstanceNameEnv)
+			}
 		}
 		/* prepare gwConnections */
 		gwEncode := strings.ToLower(cfg.Connector.GWEncode)
@@ -496,7 +515,15 @@ func (cfg *Config) LoadConnectorDTO(data []byte) (*ConnectorDTO, error) {
 	/* process PMC */
 	if cfg.IsPMC() {
 		newCfg.Connector.InstallationMode = InstallationModePMC
-		newCfg.DSConnection.HostName = os.Getenv(ParentInstanceNameEnv)
+		/* don't fake a DSConnection.HostName before any real config exists:
+		   checkAccess's bootstrap bypass relies on it staying empty until the connector
+		   has actually received a config, same as every other installation mode.
+		   newCfg.GWConnections was already set above from the incoming payload (loadConnector),
+		   so a push that itself carries the first enabled GWConnection closes the bypass
+		   starting with that push. */
+		if newCfg.GWConnections.HasEnabled() {
+			newCfg.DSConnection.HostName = os.Getenv(ParentInstanceNameEnv)
+		}
 	}
 	/* prepare gwConnections */
 	gwEncode := strings.ToLower(newCfg.Connector.GWEncode)

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -201,6 +201,58 @@ dsConnection:
 	assert.Contains(t, string(data), "controllerAddr: :8011")
 }
 
+func TestIsPMCDSConnectionGating(t *testing.T) {
+	once = sync.Once{}
+	configYAML := []byte(`
+connector:
+  agentId: "3dcd9a52-949d-4531-a3b0-b14622f7dd39"
+  appName: "test-app"
+  appType: "NAGIOS"
+dsConnection:
+  hostName: ""
+`)
+
+	tmpFile, err := os.CreateTemp("", "config")
+	assert.NoError(t, err)
+	defer os.Remove(tmpFile.Name())
+	_, err = tmpFile.Write(configYAML)
+	assert.NoError(t, err)
+	err = tmpFile.Close()
+	assert.NoError(t, err)
+
+	t.Setenv(ConfigEnv, tmpFile.Name())
+	t.Setenv(InstallationModeEnv, InstallationModePMC)
+	t.Setenv(ParentInstanceNameEnv, "parent.example.local")
+
+	// A fresh PMC connector with no enabled GWConnections yet must not have its DSConnection.HostName forced -
+	// checkAccess's bootstrap bypass relies on it staying empty until the connector has actually received a config,
+	// same as any other installation mode. (defaults() pre-populates GWConnections with empty placeholder entries,
+	// so this also guards against gating on plain slice length instead of HasEnabled().)
+	cfg := GetConfig()
+	assert.Equal(t, "", cfg.DSConnection.HostName)
+	assert.False(t, cfg.GWConnections.HasEnabled())
+
+	// once a push carries a real, enabled GWConnection, the override must apply within that same push -
+	// even overriding a wrong dalekservicesConnection.hostName in the payload
+	dto := []byte(`
+{
+  "agentId": "3dcd9a52-949d-4531-a3b0-b14622f7dd39",
+  "appName": "test-app",
+  "appType": "NAGIOS",
+  "dalekservicesConnection": {
+    "hostName": "dalekservices:3001"
+  },
+  "groundworkConnections": [{
+    "id": 1,
+    "enabled": true,
+    "hostName": "http://foundation:8080/api"
+  }]
+}`)
+	_, err = cfg.LoadConnectorDTO(dto)
+	assert.NoError(t, err)
+	assert.Equal(t, "parent.example.local", cfg.DSConnection.HostName)
+}
+
 func TestMarshaling(t *testing.T) {
 	configYAML := []byte(`
 connector:


### PR DESCRIPTION
GetConfig() and LoadConnectorDTO() forced DSConnection.HostName to PARENT_INSTANCE_NAME unconditionally whenever IsPMC() is true, including before the connector has ever received any config. Since checkAccess's bootstrap auth bypass requires dsClient.HostName == "" && len(gwClients) == 0, this permanently closed the bypass on a PMC connector before it existed -- not even a legitimate first push from the parent, using correct credentials, could land: Basic auth needs gwClients != 0 (only populated from an already-applied config), and GWOS-header auth isn't the mechanism dalekservices uses for PMC in the first place.

Gate the override on the connector already having at least one enabled GWConnection (GWConnections.HasEnabled(), new helper -- defaults() pre-populates GWConnections with 4 empty placeholder entries for indexed env-var binding, so a plain length check would always be true and defeat the fix). This is the same signal startTransport() already uses to decide whether gwClients gets populated, so it stays consistent with what actually closes the bypass, and requires no install-time seeding:

- Fresh PMC install: GWConnections has no enabled entries yet, override doesn't fire, dsClient.HostName stays "", bootstrap bypass opens exactly like STANDALONE/CMC. LoadConnectorDTO's own GWConnections gets set from the incoming payload earlier in the same call (loadConnector), so a push that itself carries the first enabled connection closes the bypass starting with that push.
- STANDALONE later converted to PMC: the file already has a real enabled GWConnections entry from before conversion, so the override fires immediately on the restart that flips INSTALLATION_MODE -- no special casing needed.

Companion to GROUNDWORK-5741's dalekservices fix (setDsHostName sending the correct hostname for a PMC child's own local push) -- that fix alone doesn't reopen this bootstrap window; this fix alone doesn't correct what hostname gets sent. Both are required together.